### PR TITLE
feat: initial implementing of passing context

### DIFF
--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -227,6 +227,9 @@ func TestMerge(t *testing.T) {
 		},
 	}
 
+	validateErr := expected.Validate()
+	assert.NoError(t, validateErr)
+
 	// Check if the result is as expected
 	if !reflect.DeepEqual(f1, expected) {
 		t.Errorf("Merge() = %v, want %v", f1, expected)

--- a/pkg/nuke/nuke_filter_test.go
+++ b/pkg/nuke/nuke_filter_test.go
@@ -1,6 +1,7 @@
 package nuke
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -27,7 +28,7 @@ func Test_NukeFiltersBad(t *testing.T) {
 	n.SetLogger(logrus.WithField("test", true))
 	n.SetRunSleep(time.Millisecond * 5)
 
-	err := n.Run()
+	err := n.Run(context.TODO())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "testResourceType: has an invalid filter")
 }
@@ -59,7 +60,7 @@ func Test_NukeFiltersMatch(t *testing.T) {
 	sErr := n.RegisterScanner(testScope, scanner)
 	assert.NoError(t, sErr)
 
-	err := n.Scan()
+	err := n.Scan(context.TODO())
 	assert.NoError(t, err)
 	assert.Equal(t, 1, n.Queue.Total())
 	assert.Equal(t, 1, n.Queue.Count(queue.ItemStateFiltered))
@@ -93,7 +94,7 @@ func Test_NukeFiltersMatchInverted(t *testing.T) {
 	sErr := n.RegisterScanner(testScope, scanner)
 	assert.NoError(t, sErr)
 
-	err := n.Scan()
+	err := n.Scan(context.TODO())
 	assert.NoError(t, err)
 	assert.Equal(t, 1, n.Queue.Total())
 	assert.Equal(t, 0, n.Queue.Count(queue.ItemStateFiltered))
@@ -126,7 +127,7 @@ func Test_Nuke_Filters_NoMatch(t *testing.T) {
 	sErr := n.RegisterScanner(testScope, scanner)
 	assert.NoError(t, sErr)
 
-	err := n.Scan()
+	err := n.Scan(context.TODO())
 	assert.NoError(t, err)
 	assert.Equal(t, 1, n.Queue.Total())
 	assert.Equal(t, 0, n.Queue.Count(queue.ItemStateFiltered))
@@ -158,7 +159,7 @@ func Test_Nuke_Filters_ErrorCustomProps(t *testing.T) {
 	sErr := n.RegisterScanner(testScope, scanner)
 	assert.NoError(t, sErr)
 
-	err := n.Scan()
+	err := n.Scan(context.TODO())
 	assert.Error(t, err)
 	assert.Equal(t, "*nuke.TestResource does not support custom properties", err.Error())
 }

--- a/pkg/nuke/nuke_run_test.go
+++ b/pkg/nuke/nuke_run_test.go
@@ -1,6 +1,7 @@
 package nuke
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -21,7 +22,7 @@ type TestResourceSuccessLister struct {
 	listed bool
 }
 
-func (l *TestResourceSuccessLister) List(o interface{}) ([]resource.Resource, error) {
+func (l *TestResourceSuccessLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
 	if l.listed {
 		return []resource.Resource{}, nil
 	}
@@ -36,13 +37,13 @@ func (r *TestResourceFailure) String() string { return "TestResourceFailure" }
 
 type TestResourceFailureLister struct{}
 
-func (l *TestResourceFailureLister) List(o interface{}) ([]resource.Resource, error) {
+func (l *TestResourceFailureLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
 	return []resource.Resource{&TestResourceFailure{}}, nil
 }
 
 type TestResourceWaitLister struct{}
 
-func (l *TestResourceWaitLister) List(o interface{}) ([]resource.Resource, error) {
+func (l *TestResourceWaitLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
 	return []resource.Resource{&TestResourceSuccess{}}, nil
 }
 
@@ -55,7 +56,7 @@ func Test_Nuke_Run_SimpleWithNoDryRun(t *testing.T) {
 	scannerErr := n.RegisterScanner(testScope, NewScanner("owner", []string{"TestResource4"}, nil))
 	assert.NoError(t, scannerErr)
 
-	runErr := n.Run()
+	runErr := n.Run(context.TODO())
 	assert.NoError(t, runErr)
 
 	assert.Equal(t, 0, n.Queue.Count(queue.ItemStateFinished))
@@ -83,7 +84,7 @@ func Test_Nuke_Run_Failure(t *testing.T) {
 	scannerErr := n.RegisterScanner(testScope, scanner)
 	assert.NoError(t, scannerErr)
 
-	runErr := n.Run()
+	runErr := n.Run(context.TODO())
 	assert.Error(t, runErr)
 
 	assert.Equal(t, 1, n.Queue.Count(queue.ItemStateFinished))
@@ -113,7 +114,7 @@ func Test_NukeRunWithMaxWaitRetries(t *testing.T) {
 	scannerErr := n.RegisterScanner(testScope, scanner)
 	assert.NoError(t, scannerErr)
 
-	runErr := n.Run()
+	runErr := n.Run(context.TODO())
 	assert.Error(t, runErr)
 	assert.Equal(t, "max wait retries of 3 exceeded", runErr.Error())
 	assert.Equal(t, 1, n.Queue.Count(queue.ItemStateWaiting))

--- a/pkg/nuke/nuke_test.go
+++ b/pkg/nuke/nuke_test.go
@@ -22,6 +22,7 @@ var testParameters = Parameters{
 	Force:      true,
 	ForceSleep: 3,
 	Quiet:      true,
+	NoDryRun:   false,
 }
 
 var testParametersRemove = Parameters{

--- a/pkg/nuke/nuke_test.go
+++ b/pkg/nuke/nuke_test.go
@@ -1,6 +1,7 @@
 package nuke
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -221,7 +222,7 @@ func Test_Nuke_Scan(t *testing.T) {
 	sErr := n.RegisterScanner(testScope, scanner)
 	assert.NoError(t, sErr)
 
-	err := n.Scan()
+	err := n.Scan(context.TODO())
 	assert.NoError(t, err)
 
 	assert.Equal(t, 2, n.Queue.Total())
@@ -252,7 +253,7 @@ func Test_Nuke_HandleRemove(t *testing.T) {
 		State:    queue.ItemStateNew,
 	}
 
-	n.HandleRemove(i)
+	n.HandleRemove(context.TODO(), i)
 	assert.Equal(t, queue.ItemStatePending, i.State)
 }
 
@@ -268,7 +269,7 @@ func Test_Nuke_HandleRemoveError(t *testing.T) {
 		State: queue.ItemStateNew,
 	}
 
-	n.HandleRemove(i)
+	n.HandleRemove(context.TODO(), i)
 	assert.Equal(t, queue.ItemStateFailed, i.State)
 }
 
@@ -297,7 +298,7 @@ func Test_Nuke_Run(t *testing.T) {
 	sErr := n.RegisterScanner(testScope, scanner)
 	assert.NoError(t, sErr)
 
-	err := n.Run()
+	err := n.Run(context.TODO())
 	assert.NoError(t, err)
 }
 
@@ -329,7 +330,7 @@ func Test_Nuke_Run_Error(t *testing.T) {
 	sErr := n.RegisterScanner(testScope, scanner)
 	assert.NoError(t, sErr)
 
-	err := n.Run()
+	err := n.Run(context.TODO())
 	assert.NoError(t, err)
 }
 
@@ -369,7 +370,7 @@ type TestResource4Lister struct {
 	attempts int
 }
 
-func (l *TestResource4Lister) List(o interface{}) ([]resource.Resource, error) {
+func (l *TestResource4Lister) List(_ context.Context, _ interface{}) ([]resource.Resource, error) {
 	l.attempts++
 
 	if l.attempts == 1 {
@@ -408,7 +409,7 @@ func Test_Nuke_Run_ItemStateHold(t *testing.T) {
 	scannerErr := n.RegisterScanner(testScope, NewScanner("owner", []string{"TestResource4"}, nil))
 	assert.NoError(t, scannerErr)
 
-	runErr := n.Run()
+	runErr := n.Run(context.TODO())
 	assert.NoError(t, runErr)
 
 	assert.Equal(t, 5, n.Queue.Count(queue.ItemStateFinished))

--- a/pkg/nuke/scan_test.go
+++ b/pkg/nuke/scan_test.go
@@ -1,6 +1,7 @@
 package nuke
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -102,7 +103,7 @@ type TestResourceLister struct {
 	RemoveError bool
 }
 
-func (l TestResourceLister) List(o interface{}) ([]resource.Resource, error) {
+func (l TestResourceLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
 	opts := o.(TestOpts)
 
 	if opts.ThrowError {
@@ -183,7 +184,7 @@ func Test_NewScannerWithMorphOpts(t *testing.T) {
 	mutateErr := scanner.RegisterMutateOptsFunc(morphOpts)
 	assert.NoError(t, mutateErr)
 
-	err := scanner.Run()
+	err := scanner.Run(context.TODO())
 	assert.NoError(t, err)
 
 	assert.Len(t, scanner.Items, 1)
@@ -238,7 +239,7 @@ func Test_NewScannerWithResourceListerError(t *testing.T) {
 	}
 
 	scanner := NewScanner("owner", []string{testResourceType}, opts)
-	err := scanner.Run()
+	err := scanner.Run(context.TODO())
 	assert.NoError(t, err)
 
 	assert.Len(t, scanner.Items, 0)
@@ -271,7 +272,7 @@ func Test_NewScannerWithResourceListerErrorSkip(t *testing.T) {
 	}
 
 	scanner := NewScanner("owner", []string{testResourceType}, opts)
-	err := scanner.Run()
+	err := scanner.Run(context.TODO())
 	assert.NoError(t, err)
 
 	assert.Len(t, scanner.Items, 0)
@@ -304,7 +305,7 @@ func Test_NewScannerWithResourceListerErrorUnknownEndpoint(t *testing.T) {
 	}
 
 	scanner := NewScanner("owner", []string{testResourceType}, opts)
-	err := scanner.Run()
+	err := scanner.Run(context.TODO())
 	assert.NoError(t, err)
 
 	assert.Len(t, scanner.Items, 0)

--- a/pkg/queue/item.go
+++ b/pkg/queue/item.go
@@ -1,6 +1,7 @@
 package queue
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ekristen/libnuke/pkg/featureflag"
@@ -54,8 +55,8 @@ func (i *Item) GetReason() string {
 
 // List calls the List method for the lister for the Type that belongs to the Item which returns
 // a list of resources or an error. This primarily is used for the HandleWait function.
-func (i *Item) List(opts interface{}) ([]resource.Resource, error) {
-	return resource.GetLister(i.Type).List(opts)
+func (i *Item) List(ctx context.Context, opts interface{}) ([]resource.Resource, error) {
+	return resource.GetLister(i.Type).List(ctx, opts)
 }
 
 // GetProperty retrieves the string value of a property on the Item's Resource if it exists.

--- a/pkg/queue/item_test.go
+++ b/pkg/queue/item_test.go
@@ -1,6 +1,8 @@
 package queue
 
 import (
+	"context"
+	"github.com/ekristen/libnuke/pkg/resource"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,10 +32,17 @@ func (r TestItemResource2) Remove() error {
 	return nil
 }
 
+type TestItemResourceLister struct{}
+
+func (l *TestItemResourceLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
+	return []resource.Resource{&TestItemResource{id: "test"}}, nil
+}
+
 var testItem = Item{
 	Resource: &TestItemResource{id: "test"},
 	State:    ItemStateNew,
 	Reason:   "brand new",
+	Type:     "TestResource",
 }
 
 var testItem2 = Item{
@@ -54,6 +63,19 @@ func Test_Item(t *testing.T) {
 
 	assert.True(t, i.Equals(i.Resource))
 	assert.False(t, i.Equals(testItem2.Resource))
+}
+
+func Test_ItemList(t *testing.T) {
+	resource.ClearRegistry()
+	resource.Register(resource.Registration{
+		Name:   "TestResource",
+		Lister: &TestItemResourceLister{},
+	})
+
+	i := testItem
+	list, err := i.List(context.TODO(), nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(list))
 }
 
 func Test_Item_LegacyStringer(t *testing.T) {
@@ -141,4 +163,75 @@ func Test_ItemPrint(t *testing.T) {
 			i.Print()
 		})
 	}
+}
+
+// ------------------------------------------------------------------------
+
+type TestItemResourceProperties struct{}
+
+func (r *TestItemResourceProperties) Remove() error {
+	return nil
+}
+func (r *TestItemResourceProperties) Properties() types.Properties {
+	return types.NewProperties().Set("test", "testing")
+}
+
+func Test_ItemEqualProperties(t *testing.T) {
+	i := &Item{
+		Resource: &TestItemResourceProperties{},
+		State:    ItemStateNew,
+		Reason:   "brand new",
+		Type:     "TestResource",
+	}
+
+	assert.True(t, i.Equals(i.Resource))
+}
+
+// ------------------------------------------------------------------------
+
+type TestItemResourceStringer struct{}
+
+func (r *TestItemResourceStringer) Remove() error {
+	return nil
+}
+func (r *TestItemResourceStringer) String() string {
+	return "test"
+}
+
+func Test_ItemEqualStringer(t *testing.T) {
+	i := &Item{
+		Resource: &TestItemResourceStringer{},
+		State:    ItemStateNew,
+		Reason:   "brand new",
+		Type:     "TestResource",
+	}
+
+	ni := &Item{
+		Resource: &TestItemResourceNothing{},
+		State:    ItemStateNew,
+		Reason:   "brand new",
+		Type:     "TestResource",
+	}
+
+	assert.True(t, i.Equals(i.Resource))
+	assert.False(t, i.Equals(ni.Resource))
+}
+
+// ------------------------------------------------------------------------
+
+type TestItemResourceNothing struct{}
+
+func (r *TestItemResourceNothing) Remove() error {
+	return nil
+}
+
+func Test_ItemEqualNothing(t *testing.T) {
+	i := &Item{
+		Resource: &TestItemResourceNothing{},
+		State:    ItemStateNew,
+		Reason:   "brand new",
+		Type:     "TestResource",
+	}
+
+	assert.False(t, i.Equals(i.Resource))
 }

--- a/pkg/queue/item_test.go
+++ b/pkg/queue/item_test.go
@@ -2,11 +2,11 @@ package queue
 
 import (
 	"context"
-	"github.com/ekristen/libnuke/pkg/resource"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/ekristen/libnuke/pkg/resource"
 	"github.com/ekristen/libnuke/pkg/types"
 )
 

--- a/pkg/resource/registry.go
+++ b/pkg/resource/registry.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
@@ -40,7 +41,7 @@ type Registration struct {
 
 // Lister is an interface that represents a resource that can be listed
 type Lister interface {
-	List(opts interface{}) ([]Resource, error)
+	List(ctx context.Context, opts interface{}) ([]Resource, error)
 }
 
 // RegisterOption is a function that can be used to manipulate the lister for a given resource type at

--- a/pkg/resource/registry_test.go
+++ b/pkg/resource/registry_test.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -9,7 +10,7 @@ import (
 
 type TestLister struct{}
 
-func (l TestLister) List(o interface{}) ([]Resource, error) { return nil, nil }
+func (l TestLister) List(_ context.Context, o interface{}) ([]Resource, error) { return nil, nil }
 
 func Test_RegisterNoScope(t *testing.T) {
 	ClearRegistry()


### PR DESCRIPTION
Working on adding passing context through to all the functions for proper context handling and processing cancelling. The new Azure, AWS and GCP golang sdk requires context for their functions and it would be better to pass the functions vs using `context.TODO()` all the time.