### PR TITLE
feat: add hold state to allow remove to drive parent removal

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -12,3 +12,9 @@ type ErrUnknownEndpoint string
 func (err ErrUnknownEndpoint) Error() string {
 	return string(err)
 }
+
+type ErrHoldResource string
+
+func (err ErrHoldResource) Error() string {
+	return string(err)
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -17,6 +17,7 @@ var (
 	ReasonWaitPending     = *color.New(color.FgBlue)
 	ReasonWaitDependency  = *color.New(color.FgCyan)
 	ReasonSuccess         = *color.New(color.FgGreen)
+	ReasonHold            = *color.New(color.FgMagenta)
 )
 
 var (

--- a/pkg/nuke/nuke_filter_test.go
+++ b/pkg/nuke/nuke_filter_test.go
@@ -1,0 +1,206 @@
+package nuke
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gotidy/ptr"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ekristen/libnuke/pkg/filter"
+	"github.com/ekristen/libnuke/pkg/queue"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+)
+
+func Test_NukeFiltersBad(t *testing.T) {
+	filters := filter.Filters{
+		testResourceType: []filter.Filter{
+			{
+				Type: filter.Exact,
+			},
+		},
+	}
+
+	n := New(testParameters, filters)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
+
+	err := n.Run()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "testResourceType: has an invalid filter")
+}
+
+func Test_NukeFiltersMatch(t *testing.T) {
+	resource.ClearRegistry()
+	resource.Register(testResourceRegistration2)
+
+	filters := filter.Filters{
+		testResourceType2: []filter.Filter{
+			{
+				Type:     filter.Exact,
+				Property: "test",
+				Value:    "testing",
+			},
+		},
+	}
+
+	n := New(testParameters, filters)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
+
+	opts := TestOpts{
+		SessionOne:     "testing",
+		SecondResource: true,
+	}
+	scanner := NewScanner("owner", []string{testResourceType2}, opts)
+
+	sErr := n.RegisterScanner(testScope, scanner)
+	assert.NoError(t, sErr)
+
+	err := n.Scan()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, n.Queue.Total())
+	assert.Equal(t, 1, n.Queue.Count(queue.ItemStateFiltered))
+}
+
+func Test_NukeFiltersMatchInverted(t *testing.T) {
+	resource.ClearRegistry()
+	resource.Register(testResourceRegistration2)
+
+	filters := filter.Filters{
+		testResourceType2: []filter.Filter{
+			{
+				Type:     filter.Exact,
+				Property: "test",
+				Value:    "testing",
+				Invert:   "true",
+			},
+		},
+	}
+
+	n := New(testParameters, filters)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
+
+	opts := TestOpts{
+		SessionOne:     "testing",
+		SecondResource: true,
+	}
+	scanner := NewScanner("owner", []string{testResourceType2}, opts)
+
+	sErr := n.RegisterScanner(testScope, scanner)
+	assert.NoError(t, sErr)
+
+	err := n.Scan()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, n.Queue.Total())
+	assert.Equal(t, 0, n.Queue.Count(queue.ItemStateFiltered))
+}
+
+func Test_Nuke_Filters_NoMatch(t *testing.T) {
+	resource.ClearRegistry()
+	resource.Register(testResourceRegistration2)
+
+	filters := filter.Filters{
+		testResourceType: []filter.Filter{
+			{
+				Type:     filter.Exact,
+				Property: "test",
+				Value:    "testing",
+			},
+		},
+	}
+
+	n := New(testParameters, filters)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
+
+	opts := TestOpts{
+		SessionOne:     "testing",
+		SecondResource: true,
+	}
+	scanner := NewScanner("owner", []string{testResourceType2}, opts)
+
+	sErr := n.RegisterScanner(testScope, scanner)
+	assert.NoError(t, sErr)
+
+	err := n.Scan()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, n.Queue.Total())
+	assert.Equal(t, 0, n.Queue.Count(queue.ItemStateFiltered))
+}
+
+func Test_Nuke_Filters_ErrorCustomProps(t *testing.T) {
+	resource.ClearRegistry()
+	resource.Register(testResourceRegistration)
+
+	filters := filter.Filters{
+		testResourceType: []filter.Filter{
+			{
+				Type:     filter.Exact,
+				Property: "Name",
+				Value:    testResourceType,
+			},
+		},
+	}
+
+	n := New(testParameters, filters)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
+
+	opts := TestOpts{
+		SessionOne: "testing",
+	}
+	scanner := NewScanner("owner", []string{testResourceType}, opts)
+
+	sErr := n.RegisterScanner(testScope, scanner)
+	assert.NoError(t, sErr)
+
+	err := n.Scan()
+	assert.Error(t, err)
+	assert.Equal(t, "*nuke.TestResource does not support custom properties", err.Error())
+}
+
+type TestResourceFilter struct {
+}
+
+func (r TestResourceFilter) Properties() types.Properties {
+	props := types.NewProperties()
+
+	tagName := ptr.String("aws:cloudformation:stack-name")
+	tagVal := "StackSet-AWSControlTowerBP-VPC-ACCOUNT-FACTORY-V1-c0bdd9c9-c338-4831-9c47-62443622c081"
+
+	props.SetTag(tagName, tagVal)
+	return props
+}
+
+func (r TestResourceFilter) Remove() error {
+	return nil
+}
+
+func Test_Nuke_Filters_Extra(t *testing.T) {
+	filters := filter.Filters{
+		testResourceType2: []filter.Filter{
+			{
+				Type:     filter.Glob,
+				Property: "tag:aws:cloudformation:stack-name",
+				Value:    "StackSet-AWSControlTowerBP*",
+			},
+		},
+	}
+
+	n := New(testParameters, filters)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
+
+	i := &queue.Item{
+		Resource: &TestResourceFilter{},
+		Type:     testResourceType2,
+	}
+
+	err := n.Filter(i)
+	assert.NoError(t, err)
+	assert.Equal(t, i.Reason, "filtered by config")
+}

--- a/pkg/nuke/nuke_run_test.go
+++ b/pkg/nuke/nuke_run_test.go
@@ -2,12 +2,14 @@ package nuke
 
 import (
 	"fmt"
-	"github.com/ekristen/libnuke/pkg/queue"
-	"github.com/ekristen/libnuke/pkg/resource"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ekristen/libnuke/pkg/queue"
+	"github.com/ekristen/libnuke/pkg/resource"
 )
 
 type TestResourceSuccess struct{}

--- a/pkg/nuke/nuke_run_test.go
+++ b/pkg/nuke/nuke_run_test.go
@@ -1,0 +1,118 @@
+package nuke
+
+import (
+	"fmt"
+	"github.com/ekristen/libnuke/pkg/queue"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+type TestResourceSuccess struct{}
+
+func (r *TestResourceSuccess) Remove() error  { return nil }
+func (r *TestResourceSuccess) String() string { return "TestResourceFailure" }
+
+type TestResourceSuccessLister struct {
+	listed bool
+}
+
+func (l *TestResourceSuccessLister) List(o interface{}) ([]resource.Resource, error) {
+	if l.listed {
+		return []resource.Resource{}, nil
+	}
+	l.listed = true
+	return []resource.Resource{&TestResourceSuccess{}}, nil
+}
+
+type TestResourceFailure struct{}
+
+func (r *TestResourceFailure) Remove() error  { return fmt.Errorf("unable to remove") }
+func (r *TestResourceFailure) String() string { return "TestResourceFailure" }
+
+type TestResourceFailureLister struct{}
+
+func (l *TestResourceFailureLister) List(o interface{}) ([]resource.Resource, error) {
+	return []resource.Resource{&TestResourceFailure{}}, nil
+}
+
+type TestResourceWaitLister struct{}
+
+func (l *TestResourceWaitLister) List(o interface{}) ([]resource.Resource, error) {
+	return []resource.Resource{&TestResourceSuccess{}}, nil
+}
+
+// Test_Nuke_Run_SimpleWithNoDryRun tests a simple run with no dry run enabled so all resources are removed.
+func Test_Nuke_Run_SimpleWithNoDryRun(t *testing.T) {
+	n := New(testParametersRemove, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
+
+	scannerErr := n.RegisterScanner(testScope, NewScanner("owner", []string{"TestResource4"}, nil))
+	assert.NoError(t, scannerErr)
+
+	runErr := n.Run()
+	assert.NoError(t, runErr)
+
+	assert.Equal(t, 0, n.Queue.Count(queue.ItemStateFinished))
+}
+
+// Test_Nuke_Run_Failure tests a run with a resource that fails to remove, so it should be in the failed state.
+// It also tests that a resource is successfully removed as well, to test the entire fail state.
+func Test_Nuke_Run_Failure(t *testing.T) {
+	n := New(testParametersRemove, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
+
+	resource.ClearRegistry()
+	resource.Register(resource.Registration{
+		Name:   "TestResourceSuccess",
+		Lister: &TestResourceSuccessLister{},
+	})
+
+	resource.Register(resource.Registration{
+		Name:   "TestResourceFailure",
+		Lister: &TestResourceFailureLister{},
+	})
+
+	scanner := NewScanner("owner", []string{"TestResourceSuccess", "TestResourceFailure"}, nil)
+	scannerErr := n.RegisterScanner(testScope, scanner)
+	assert.NoError(t, scannerErr)
+
+	runErr := n.Run()
+	assert.Error(t, runErr)
+
+	assert.Equal(t, 1, n.Queue.Count(queue.ItemStateFinished))
+	assert.Equal(t, 1, n.Queue.Count(queue.ItemStateFailed))
+}
+
+var testParametersMaxWaitRetries = Parameters{
+	Force:          true,
+	ForceSleep:     3,
+	Quiet:          true,
+	NoDryRun:       true,
+	MaxWaitRetries: 3,
+}
+
+func Test_NukeRunWithMaxWaitRetries(t *testing.T) {
+	n := New(testParametersMaxWaitRetries, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
+
+	resource.ClearRegistry()
+	resource.Register(resource.Registration{
+		Name:   "TestResourceSuccess",
+		Lister: &TestResourceWaitLister{},
+	})
+
+	scanner := NewScanner("owner", []string{"TestResourceSuccess"}, nil)
+	scannerErr := n.RegisterScanner(testScope, scanner)
+	assert.NoError(t, scannerErr)
+
+	runErr := n.Run()
+	assert.Error(t, runErr)
+	assert.Equal(t, "max wait retries of 3 exceeded", runErr.Error())
+	assert.Equal(t, 1, n.Queue.Count(queue.ItemStateWaiting))
+}

--- a/pkg/nuke/nuke_test.go
+++ b/pkg/nuke/nuke_test.go
@@ -2,7 +2,6 @@ package nuke
 
 import (
 	"fmt"
-	liberrors "github.com/ekristen/libnuke/pkg/errors"
 	"io"
 	"os"
 	"strings"
@@ -13,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
+	liberrors "github.com/ekristen/libnuke/pkg/errors"
 	"github.com/ekristen/libnuke/pkg/queue"
 	"github.com/ekristen/libnuke/pkg/resource"
 )
@@ -339,17 +339,16 @@ var TestResource4Resources []resource.Resource
 
 type TestResource4 struct {
 	id       string
-	parentId string
-	attempts int
+	parentID string
 }
 
 func (r *TestResource4) Remove() error {
-	if r.parentId != "" {
+	if r.parentID != "" {
 		parentFound := false
 
 		for _, o := range TestResource4Resources {
 			id := o.(resource.LegacyStringer).String()
-			if id == r.parentId {
+			if id == r.parentID {
 				parentFound = true
 			}
 		}
@@ -378,12 +377,12 @@ func (l *TestResource4Lister) List(o interface{}) ([]resource.Resource, error) {
 			if x == 0 {
 				TestResource4Resources = append(TestResource4Resources, &TestResource4{
 					id:       fmt.Sprintf("resource-%d", x),
-					parentId: "",
+					parentID: "",
 				})
 			} else {
 				TestResource4Resources = append(TestResource4Resources, &TestResource4{
 					id:       fmt.Sprintf("resource-%d", x),
-					parentId: "resource-0",
+					parentID: "resource-0",
 				})
 			}
 		}

--- a/pkg/nuke/nuke_test.go
+++ b/pkg/nuke/nuke_test.go
@@ -2,20 +2,19 @@ package nuke
 
 import (
 	"fmt"
+	liberrors "github.com/ekristen/libnuke/pkg/errors"
 	"io"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gotidy/ptr"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ekristen/libnuke/pkg/featureflag"
-	"github.com/ekristen/libnuke/pkg/filter"
 	"github.com/ekristen/libnuke/pkg/queue"
 	"github.com/ekristen/libnuke/pkg/resource"
-	"github.com/ekristen/libnuke/pkg/types"
 )
 
 var testParameters = Parameters{
@@ -24,11 +23,19 @@ var testParameters = Parameters{
 	Quiet:      true,
 }
 
+var testParametersRemove = Parameters{
+	Force:      true,
+	ForceSleep: 3,
+	Quiet:      true,
+	NoDryRun:   true,
+}
+
 const testScope resource.Scope = "test"
 
 func Test_Nuke_Version(t *testing.T) {
 	n := New(testParameters, nil)
 	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
 
 	n.RegisterVersion("1.0.0-test")
 
@@ -55,12 +62,9 @@ func Test_Nuke_Version(t *testing.T) {
 }
 
 func Test_Nuke_FeatureFlag(t *testing.T) {
-	n := &Nuke{
-		Parameters:   testParameters,
-		Queue:        queue.Queue{},
-		FeatureFlags: &featureflag.FeatureFlags{},
-		log:          logrus.WithField("test", true),
-	}
+	n := New(testParameters, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
 
 	n.RegisterFeatureFlags("test", ptr.Bool(true), ptr.Bool(true))
 
@@ -74,24 +78,18 @@ func Test_Nuke_FeatureFlag(t *testing.T) {
 }
 
 func Test_Nuke_Validators_Default(t *testing.T) {
-	n := &Nuke{
-		Parameters:   testParameters,
-		Queue:        queue.Queue{},
-		FeatureFlags: &featureflag.FeatureFlags{},
-		log:          logrus.WithField("test", true),
-	}
+	n := New(testParameters, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
 
 	err := n.Validate()
 	assert.NoError(t, err)
 }
 
 func Test_Nuke_Validators_Register1(t *testing.T) {
-	n := &Nuke{
-		Parameters:   testParameters,
-		Queue:        queue.Queue{},
-		FeatureFlags: &featureflag.FeatureFlags{},
-		log:          logrus.WithField("test", true),
-	}
+	n := New(testParameters, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
 
 	n.RegisterValidateHandler(func() error {
 		return fmt.Errorf("validator called")
@@ -103,12 +101,9 @@ func Test_Nuke_Validators_Register1(t *testing.T) {
 }
 
 func Test_Nuke_Validators_Register2(t *testing.T) {
-	n := &Nuke{
-		Parameters:   testParameters,
-		Queue:        queue.Queue{},
-		FeatureFlags: &featureflag.FeatureFlags{},
-		log:          logrus.WithField("test", true),
-	}
+	n := New(testParameters, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
 
 	n.RegisterValidateHandler(func() error {
 		return fmt.Errorf("validator called")
@@ -122,16 +117,14 @@ func Test_Nuke_Validators_Register2(t *testing.T) {
 }
 
 func Test_Nuke_Validators_Error(t *testing.T) {
-	n := &Nuke{
-		Parameters: Parameters{
-			Force:      true,
-			ForceSleep: 1,
-			Quiet:      true,
-		},
-		Queue:        queue.Queue{},
-		FeatureFlags: &featureflag.FeatureFlags{},
-		log:          logrus.WithField("test", true),
+	p := Parameters{
+		Force:      true,
+		ForceSleep: 1,
+		Quiet:      true,
 	}
+	n := New(p, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
 
 	err := n.Validate()
 	assert.Error(t, err)
@@ -139,12 +132,9 @@ func Test_Nuke_Validators_Error(t *testing.T) {
 }
 
 func Test_Nuke_ResourceTypes(t *testing.T) {
-	n := &Nuke{
-		Parameters:   testParameters,
-		Queue:        queue.Queue{},
-		FeatureFlags: &featureflag.FeatureFlags{},
-		log:          logrus.WithField("test", true),
-	}
+	n := New(testParameters, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
 
 	n.RegisterResourceTypes(testScope, "TestResource")
 
@@ -152,12 +142,9 @@ func Test_Nuke_ResourceTypes(t *testing.T) {
 }
 
 func Test_Nuke_Scanners(t *testing.T) {
-	n := &Nuke{
-		Parameters:   testParameters,
-		Queue:        queue.Queue{},
-		FeatureFlags: &featureflag.FeatureFlags{},
-		log:          logrus.WithField("test", true),
-	}
+	n := New(testParameters, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
 
 	opts := struct {
 		name string
@@ -174,12 +161,9 @@ func Test_Nuke_Scanners(t *testing.T) {
 }
 
 func Test_Nuke_Scanners_Duplicate(t *testing.T) {
-	n := &Nuke{
-		Parameters:   testParameters,
-		Queue:        queue.Queue{},
-		FeatureFlags: &featureflag.FeatureFlags{},
-		log:          logrus.WithField("test", true),
-	}
+	n := New(testParameters, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
 
 	opts := struct {
 		name string
@@ -199,12 +183,9 @@ func Test_Nuke_Scanners_Duplicate(t *testing.T) {
 }
 
 func Test_Nuke_RegisterPrompt(t *testing.T) {
-	n := &Nuke{
-		Parameters:   testParameters,
-		Queue:        queue.Queue{},
-		FeatureFlags: &featureflag.FeatureFlags{},
-		log:          logrus.WithField("test", true),
-	}
+	n := New(testParameters, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
 
 	n.RegisterPrompt(func() error {
 		return fmt.Errorf("prompt error")
@@ -228,12 +209,9 @@ func Test_Nuke_Scan(t *testing.T) {
 		},
 	})
 
-	n := &Nuke{
-		Parameters:   testParameters,
-		Queue:        queue.Queue{},
-		FeatureFlags: &featureflag.FeatureFlags{},
-		log:          logrus.WithField("test", true),
-	}
+	n := New(testParameters, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
 
 	opts := TestOpts{
 		SessionOne: "testing",
@@ -251,153 +229,6 @@ func Test_Nuke_Scan(t *testing.T) {
 	assert.Equal(t, 1, n.Queue.Count(queue.ItemStateFiltered))
 }
 
-func Test_Nuke_Filters_Match(t *testing.T) {
-	resource.ClearRegistry()
-	resource.Register(testResourceRegistration2)
-
-	n := &Nuke{
-		Parameters:   testParameters,
-		Queue:        queue.Queue{},
-		FeatureFlags: &featureflag.FeatureFlags{},
-		Filters: filter.Filters{
-			testResourceType2: []filter.Filter{
-				{
-					Type:     filter.Exact,
-					Property: "test",
-					Value:    "testing",
-				},
-			},
-		},
-		log: logrus.WithField("test", true),
-	}
-
-	opts := TestOpts{
-		SessionOne:     "testing",
-		SecondResource: true,
-	}
-	scanner := NewScanner("owner", []string{testResourceType2}, opts)
-
-	sErr := n.RegisterScanner(testScope, scanner)
-	assert.NoError(t, sErr)
-
-	err := n.Scan()
-	assert.NoError(t, err)
-	assert.Equal(t, 1, n.Queue.Total())
-	assert.Equal(t, 1, n.Queue.Count(queue.ItemStateFiltered))
-}
-
-func Test_Nuke_Filters_NoMatch(t *testing.T) {
-	resource.ClearRegistry()
-	resource.Register(testResourceRegistration2)
-
-	n := &Nuke{
-		Parameters:   testParameters,
-		Queue:        queue.Queue{},
-		FeatureFlags: &featureflag.FeatureFlags{},
-		Filters: filter.Filters{
-			testResourceType: []filter.Filter{
-				{
-					Type:     filter.Exact,
-					Property: "test",
-					Value:    "testing",
-				},
-			},
-		},
-		log: logrus.WithField("test", true),
-	}
-
-	opts := TestOpts{
-		SessionOne:     "testing",
-		SecondResource: true,
-	}
-	scanner := NewScanner("owner", []string{testResourceType2}, opts)
-
-	sErr := n.RegisterScanner(testScope, scanner)
-	assert.NoError(t, sErr)
-
-	err := n.Scan()
-	assert.NoError(t, err)
-	assert.Equal(t, 1, n.Queue.Total())
-	assert.Equal(t, 0, n.Queue.Count(queue.ItemStateFiltered))
-}
-
-func Test_Nuke_Filters_ErrorCustomProps(t *testing.T) {
-	resource.ClearRegistry()
-	resource.Register(testResourceRegistration)
-
-	n := &Nuke{
-		Parameters:   testParameters,
-		Queue:        queue.Queue{},
-		FeatureFlags: &featureflag.FeatureFlags{},
-		Filters: filter.Filters{
-			testResourceType: []filter.Filter{
-				{
-					Type:     filter.Exact,
-					Property: "Name",
-					Value:    testResourceType,
-				},
-			},
-		},
-		log: logrus.WithField("test", true),
-	}
-
-	opts := TestOpts{
-		SessionOne: "testing",
-	}
-	scanner := NewScanner("owner", []string{testResourceType}, opts)
-
-	sErr := n.RegisterScanner(testScope, scanner)
-	assert.NoError(t, sErr)
-
-	err := n.Scan()
-	assert.Error(t, err)
-	assert.Equal(t, "*nuke.TestResource does not support custom properties", err.Error())
-}
-
-type TestResourceFilter struct {
-}
-
-func (r TestResourceFilter) Properties() types.Properties {
-	props := types.NewProperties()
-
-	tagName := ptr.String("aws:cloudformation:stack-name")
-	tagVal := "StackSet-AWSControlTowerBP-VPC-ACCOUNT-FACTORY-V1-c0bdd9c9-c338-4831-9c47-62443622c081"
-
-	props.SetTag(tagName, tagVal)
-	return props
-}
-
-func (r TestResourceFilter) Remove() error {
-	return nil
-}
-
-func Test_Nuke_Filters_Extra(t *testing.T) {
-	n := &Nuke{
-		Parameters:   testParameters,
-		Queue:        queue.Queue{},
-		FeatureFlags: &featureflag.FeatureFlags{},
-		Filters: filter.Filters{
-			testResourceType2: []filter.Filter{
-				{
-					Type:     filter.Glob,
-					Property: "tag:aws:cloudformation:stack-name",
-					Value:    "StackSet-AWSControlTowerBP*",
-				},
-			},
-		},
-		log: logrus.WithField("test", true),
-	}
-
-	i := &queue.Item{
-		Resource: &TestResourceFilter{},
-		Type:     testResourceType2,
-	}
-
-	err := n.Filter(i)
-	assert.NoError(t, err)
-	assert.Equal(t, i.Reason, "filtered by config")
-}
-
 // ---------------------------------------------------------------------
 
 type TestResource3 struct {
@@ -412,11 +243,9 @@ func (r TestResource3) Remove() error {
 }
 
 func Test_Nuke_HandleRemove(t *testing.T) {
-	n := &Nuke{
-		Parameters: testParameters,
-		Queue:      queue.Queue{},
-		log:        logrus.WithField("test", true),
-	}
+	n := New(testParameters, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
 
 	i := &queue.Item{
 		Resource: &TestResource3{},
@@ -428,11 +257,9 @@ func Test_Nuke_HandleRemove(t *testing.T) {
 }
 
 func Test_Nuke_HandleRemoveError(t *testing.T) {
-	n := &Nuke{
-		Parameters: testParameters,
-		Queue:      queue.Queue{},
-		log:        logrus.WithField("test", true),
-	}
+	n := New(testParameters, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
 
 	i := &queue.Item{
 		Resource: &TestResource3{
@@ -451,17 +278,16 @@ func Test_Nuke_Run(t *testing.T) {
 	resource.ClearRegistry()
 	resource.Register(testResourceRegistration)
 
-	n := &Nuke{
-		Parameters: Parameters{
-			Force:      true,
-			ForceSleep: 3,
-			Quiet:      true,
-			NoDryRun:   true,
-		},
-		Queue:        queue.Queue{},
-		FeatureFlags: &featureflag.FeatureFlags{},
-		log:          logrus.WithField("test", true),
+	p := Parameters{
+		Force:      true,
+		ForceSleep: 3,
+		Quiet:      true,
+		NoDryRun:   true,
 	}
+
+	n := New(p, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
 
 	opts := TestOpts{
 		SessionOne: "testing",
@@ -485,17 +311,15 @@ func Test_Nuke_Run_Error(t *testing.T) {
 		},
 	})
 
-	n := &Nuke{
-		Parameters: Parameters{
-			Force:      true,
-			ForceSleep: 3,
-			Quiet:      true,
-			NoDryRun:   true,
-		},
-		Queue:        queue.Queue{},
-		FeatureFlags: &featureflag.FeatureFlags{},
-		log:          logrus.WithField("test", true),
+	p := Parameters{
+		Force:      true,
+		ForceSleep: 3,
+		Quiet:      true,
+		NoDryRun:   true,
 	}
+	n := New(p, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
 
 	opts := TestOpts{
 		SessionOne: "testing",
@@ -508,3 +332,87 @@ func Test_Nuke_Run_Error(t *testing.T) {
 	err := n.Run()
 	assert.NoError(t, err)
 }
+
+// ------------------------------------------------------------
+
+var TestResource4Resources []resource.Resource
+
+type TestResource4 struct {
+	id       string
+	parentId string
+	attempts int
+}
+
+func (r *TestResource4) Remove() error {
+	if r.parentId != "" {
+		parentFound := false
+
+		for _, o := range TestResource4Resources {
+			id := o.(resource.LegacyStringer).String()
+			if id == r.parentId {
+				parentFound = true
+			}
+		}
+
+		if parentFound {
+			return liberrors.ErrHoldResource("waiting for parent to be removed")
+		}
+	}
+
+	return nil
+}
+
+func (r *TestResource4) String() string {
+	return r.id
+}
+
+type TestResource4Lister struct {
+	attempts int
+}
+
+func (l *TestResource4Lister) List(o interface{}) ([]resource.Resource, error) {
+	l.attempts++
+
+	if l.attempts == 1 {
+		for x := 0; x < 5; x++ {
+			if x == 0 {
+				TestResource4Resources = append(TestResource4Resources, &TestResource4{
+					id:       fmt.Sprintf("resource-%d", x),
+					parentId: "",
+				})
+			} else {
+				TestResource4Resources = append(TestResource4Resources, &TestResource4{
+					id:       fmt.Sprintf("resource-%d", x),
+					parentId: "resource-0",
+				})
+			}
+		}
+	} else if l.attempts > 3 {
+		TestResource4Resources = TestResource4Resources[1:]
+	}
+
+	return TestResource4Resources, nil
+}
+
+func Test_Nuke_Run_ItemStateHold(t *testing.T) {
+	n := New(testParametersRemove, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
+
+	resource.ClearRegistry()
+	resource.Register(resource.Registration{
+		Name:   "TestResource4",
+		Scope:  testScope,
+		Lister: &TestResource4Lister{},
+	})
+
+	scannerErr := n.RegisterScanner(testScope, NewScanner("owner", []string{"TestResource4"}, nil))
+	assert.NoError(t, scannerErr)
+
+	runErr := n.Run()
+	assert.NoError(t, runErr)
+
+	assert.Equal(t, 5, n.Queue.Count(queue.ItemStateFinished))
+}
+
+// -----------------------------------------------

--- a/pkg/nuke/scan_test.go
+++ b/pkg/nuke/scan_test.go
@@ -180,7 +180,8 @@ func Test_NewScannerWithMorphOpts(t *testing.T) {
 	}
 
 	scanner := NewScanner("owner", []string{testResourceType}, opts)
-	scanner.RegisterMutateOptsFunc(morphOpts)
+	mutateErr := scanner.RegisterMutateOptsFunc(morphOpts)
+	assert.NoError(t, mutateErr)
 
 	err := scanner.Run()
 	assert.NoError(t, err)

--- a/pkg/nuke/scan_test.go
+++ b/pkg/nuke/scan_test.go
@@ -193,6 +193,28 @@ func Test_NewScannerWithMorphOpts(t *testing.T) {
 	}
 }
 
+func Test_NewScannerWithDuplicateMorphOpts(t *testing.T) {
+	resource.ClearRegistry()
+	resource.Register(testResourceRegistration)
+
+	opts := TestOpts{
+		SessionOne: "testing",
+	}
+
+	morphOpts := func(o interface{}, resourceType string) interface{} {
+		o1 := o.(TestOpts)
+		o1.SessionTwo = o1.SessionOne + "-" + resourceType
+		return o1
+	}
+
+	scanner := NewScanner("owner", []string{testResourceType}, opts)
+	optErr := scanner.RegisterMutateOptsFunc(morphOpts)
+	assert.NoError(t, optErr)
+
+	optErr = scanner.RegisterMutateOptsFunc(morphOpts)
+	assert.Error(t, optErr)
+}
+
 func Test_NewScannerWithResourceListerError(t *testing.T) {
 	resource.ClearRegistry()
 	logrus.AddHook(&TestGlobalHook{

--- a/pkg/queue/item.go
+++ b/pkg/queue/item.go
@@ -13,6 +13,7 @@ type ItemState int
 const (
 	ItemStateNew ItemState = iota
 	ItemStateNewDependency
+	ItemStateHold
 	ItemStatePending
 	ItemStatePendingDependency
 	ItemStateWaiting
@@ -111,6 +112,8 @@ func (i *Item) Print() {
 		log.Log(i.Owner, i.Type, i.Resource, log.ReasonWaitPending, "would remove")
 	case ItemStateNewDependency:
 		log.Log(i.Owner, i.Type, i.Resource, log.ReasonWaitDependency, "would remove after dependencies")
+	case ItemStateHold:
+		log.Log(i.Owner, i.Type, i.Resource, log.ReasonHold, "waiting for parent removal")
 	case ItemStatePending:
 		log.Log(i.Owner, i.Type, i.Resource, log.ReasonRemoveTriggered, "triggered remove")
 	case ItemStatePendingDependency:

--- a/pkg/queue/item_test.go
+++ b/pkg/queue/item_test.go
@@ -8,20 +8,20 @@ import (
 	"github.com/ekristen/libnuke/pkg/types"
 )
 
-type TestItemResource struct{}
+type TestItemResource struct {
+	id string
+}
 
-func (r TestItemResource) Properties() types.Properties {
+func (r *TestItemResource) Properties() types.Properties {
 	props := types.NewProperties()
-	props.Set("test", "testing")
+	props.Set(r.id, "testing")
 	return props
 }
-
-func (r TestItemResource) Remove() error {
+func (r *TestItemResource) Remove() error {
 	return nil
 }
-
-func (r TestItemResource) String() string {
-	return "test"
+func (r *TestItemResource) String() string {
+	return r.id
 }
 
 type TestItemResource2 struct{}
@@ -31,7 +31,7 @@ func (r TestItemResource2) Remove() error {
 }
 
 var testItem = Item{
-	Resource: &TestItemResource{},
+	Resource: &TestItemResource{id: "test"},
 	State:    ItemStateNew,
 	Reason:   "brand new",
 }
@@ -53,7 +53,6 @@ func Test_Item(t *testing.T) {
 	assert.Equal(t, "testing", propVal)
 
 	assert.True(t, i.Equals(i.Resource))
-
 	assert.False(t, i.Equals(testItem2.Resource))
 }
 
@@ -100,6 +99,11 @@ func Test_ItemPrint(t *testing.T) {
 			want:  "would remove after dependencies",
 		},
 		{
+			name:  "pending-dependency",
+			state: ItemStatePendingDependency,
+			want:  "waiting on dependencies (brand new)",
+		},
+		{
 			name:  "waiting",
 			state: ItemStateWaiting,
 			want:  "waiting",
@@ -118,6 +122,11 @@ func Test_ItemPrint(t *testing.T) {
 			name:  "finished",
 			state: ItemStateFinished,
 			want:  "finished",
+		},
+		{
+			name:  "hold",
+			state: ItemStateHold,
+			want:  "waiting for parent removal",
 		},
 	}
 


### PR DESCRIPTION
This adds the ability to create direct dependencies mainly for use by AWS CloudFormation removal or any other resource that has a parentId that is directly tracked in the same listing.