### PR TITLE
feat: split registry to its own package

### DIFF
--- a/pkg/filter/testdata/filters.yaml
+++ b/pkg/filter/testdata/filters.yaml
@@ -1,0 +1,13 @@
+filters:
+  __global__:
+    - name: prop3
+      type: exact
+      value: value3
+  Resource1:
+    - name: prop1
+      type: exact
+      value: value1
+  Resource2:
+    - name: prop2
+      type: exact
+      value: value2

--- a/pkg/nuke/nuke.go
+++ b/pkg/nuke/nuke.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ekristen/libnuke/pkg/registry"
 	"io"
 	"slices"
 	"time"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/ekristen/libnuke/pkg/filter"
 	"github.com/ekristen/libnuke/pkg/queue"
+	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
 	"github.com/ekristen/libnuke/pkg/types"
 	"github.com/ekristen/libnuke/pkg/utils"

--- a/pkg/nuke/nuke.go
+++ b/pkg/nuke/nuke.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/ekristen/libnuke/pkg/registry"
 	"io"
 	"slices"
 	"time"
@@ -70,8 +71,8 @@ type Nuke struct {
 	Settings   *libsettings.Settings // Settings is the collection of settings that will be used to control resource behavior
 
 	ValidateHandlers []func() error
-	ResourceTypes    map[resource.Scope]types.Collection
-	Scanners         map[resource.Scope][]*scanner.Scanner
+	ResourceTypes    map[registry.Scope]types.Collection
+	Scanners         map[registry.Scope][]*scanner.Scanner
 	Queue            *queue.Queue // Queue is the queue of resources that will be processed
 
 	scannerHashes []string      // scannerHashes is used to track if a scanner has already been registered
@@ -134,9 +135,9 @@ func (n *Nuke) RegisterValidateHandler(handler func() error) {
 // RegisterResourceTypes is used to register resource types against a scope. A scope is a string that is used to
 // group resource types together. For example, you could have a scope of "aws" and register all AWS resource types.
 // For Azure, you have to register resources by tenant or subscription or even resource group.
-func (n *Nuke) RegisterResourceTypes(scope resource.Scope, resourceTypes ...string) {
+func (n *Nuke) RegisterResourceTypes(scope registry.Scope, resourceTypes ...string) {
 	if n.ResourceTypes == nil {
-		n.ResourceTypes = make(map[resource.Scope]types.Collection)
+		n.ResourceTypes = make(map[registry.Scope]types.Collection)
 	}
 
 	n.ResourceTypes[scope] = append(n.ResourceTypes[scope], resourceTypes...)
@@ -145,9 +146,9 @@ func (n *Nuke) RegisterResourceTypes(scope resource.Scope, resourceTypes ...stri
 // RegisterScanner is used to register a scanner against a scope. A scope is a string that is used to group resource
 // types together. A scanner is what is responsible for actually querying the API for resources and adding them to
 // the queue for processing.
-func (n *Nuke) RegisterScanner(scope resource.Scope, instance *scanner.Scanner) error {
+func (n *Nuke) RegisterScanner(scope registry.Scope, instance *scanner.Scanner) error {
 	if n.Scanners == nil {
-		n.Scanners = make(map[resource.Scope][]*scanner.Scanner)
+		n.Scanners = make(map[registry.Scope][]*scanner.Scanner)
 	}
 
 	hashString := fmt.Sprintf("%s-%s", scope, instance.Owner)
@@ -371,7 +372,7 @@ func (n *Nuke) runScanner(ctx context.Context, resourceScanner *scanner.Scanner,
 	for item := range resourceScanner.Items {
 		// Experimental Feature
 		if n.Parameters.WaitOnDependencies {
-			reg := resource.GetRegistration(item.Type)
+			reg := registry.GetRegistration(item.Type)
 			if len(reg.DependsOn) > 0 {
 				item.State = queue.ItemStateNewDependency
 			}
@@ -555,7 +556,7 @@ func (n *Nuke) HandleRemove(ctx context.Context, item *queue.Item) {
 // HandleWaitDependency is used to handle the waiting of a resource. It will check if the resource has any dependencies
 // and if it does, it will check if the dependencies have been removed. If they have, it will trigger the remove handler.
 func (n *Nuke) HandleWaitDependency(ctx context.Context, item *queue.Item) {
-	reg := resource.GetRegistration(item.Type)
+	reg := registry.GetRegistration(item.Type)
 	depCount := 0
 	for _, dep := range reg.DependsOn {
 		cnt := n.Queue.CountByType(dep,

--- a/pkg/nuke/nuke_filter_test.go
+++ b/pkg/nuke/nuke_filter_test.go
@@ -2,7 +2,6 @@ package nuke
 
 import (
 	"context"
-	"github.com/ekristen/libnuke/pkg/registry"
 	"testing"
 	"time"
 
@@ -12,6 +11,7 @@ import (
 
 	"github.com/ekristen/libnuke/pkg/filter"
 	"github.com/ekristen/libnuke/pkg/queue"
+	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/scanner"
 	"github.com/ekristen/libnuke/pkg/types"
 )

--- a/pkg/nuke/nuke_filter_test.go
+++ b/pkg/nuke/nuke_filter_test.go
@@ -2,6 +2,7 @@ package nuke
 
 import (
 	"context"
+	"github.com/ekristen/libnuke/pkg/registry"
 	"testing"
 	"time"
 
@@ -11,7 +12,6 @@ import (
 
 	"github.com/ekristen/libnuke/pkg/filter"
 	"github.com/ekristen/libnuke/pkg/queue"
-	"github.com/ekristen/libnuke/pkg/resource"
 	"github.com/ekristen/libnuke/pkg/scanner"
 	"github.com/ekristen/libnuke/pkg/types"
 )
@@ -35,8 +35,8 @@ func Test_NukeFiltersBad(t *testing.T) {
 }
 
 func Test_NukeFiltersMatch(t *testing.T) {
-	resource.ClearRegistry()
-	resource.Register(TestResourceRegistration2)
+	registry.ClearRegistry()
+	registry.Register(TestResourceRegistration2)
 
 	filters := filter.Filters{
 		TestResourceType2: []filter.Filter{
@@ -68,8 +68,8 @@ func Test_NukeFiltersMatch(t *testing.T) {
 }
 
 func Test_NukeFiltersMatchInverted(t *testing.T) {
-	resource.ClearRegistry()
-	resource.Register(TestResourceRegistration2)
+	registry.ClearRegistry()
+	registry.Register(TestResourceRegistration2)
 
 	filters := filter.Filters{
 		TestResourceType2: []filter.Filter{
@@ -102,8 +102,8 @@ func Test_NukeFiltersMatchInverted(t *testing.T) {
 }
 
 func Test_Nuke_Filters_NoMatch(t *testing.T) {
-	resource.ClearRegistry()
-	resource.Register(TestResourceRegistration2)
+	registry.ClearRegistry()
+	registry.Register(TestResourceRegistration2)
 
 	filters := filter.Filters{
 		TestResourceType: []filter.Filter{
@@ -135,8 +135,8 @@ func Test_Nuke_Filters_NoMatch(t *testing.T) {
 }
 
 func Test_Nuke_Filters_ErrorCustomProps(t *testing.T) {
-	resource.ClearRegistry()
-	resource.Register(TestResourceRegistration)
+	registry.ClearRegistry()
+	registry.Register(TestResourceRegistration)
 
 	filters := filter.Filters{
 		TestResourceType: []filter.Filter{

--- a/pkg/nuke/nuke_run_test.go
+++ b/pkg/nuke/nuke_run_test.go
@@ -3,7 +3,6 @@ package nuke
 import (
 	"context"
 	"fmt"
-	"github.com/ekristen/libnuke/pkg/registry"
 	"testing"
 	"time"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ekristen/libnuke/pkg/queue"
+	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
 	"github.com/ekristen/libnuke/pkg/scanner"
 )

--- a/pkg/nuke/nuke_run_test.go
+++ b/pkg/nuke/nuke_run_test.go
@@ -3,6 +3,7 @@ package nuke
 import (
 	"context"
 	"fmt"
+	"github.com/ekristen/libnuke/pkg/registry"
 	"testing"
 	"time"
 
@@ -57,8 +58,8 @@ func Test_Nuke_Run_Simple(t *testing.T) {
 	n.SetLogger(logrus.WithField("test", true))
 	n.SetRunSleep(time.Millisecond * 5)
 
-	resource.ClearRegistry()
-	resource.Register(&resource.Registration{
+	registry.ClearRegistry()
+	registry.Register(&registry.Registration{
 		Name:   "TestResourceSuccess",
 		Lister: &TestResourceSuccessLister{},
 	})
@@ -82,8 +83,8 @@ func Test_Nuke_Run_ScanError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
 	defer cancel()
 
-	resource.ClearRegistry()
-	resource.Register(&resource.Registration{
+	registry.ClearRegistry()
+	registry.Register(&registry.Registration{
 		Name:   "TestResourceSuccess",
 		Lister: &TestResourceSuccessLister{},
 	})
@@ -125,8 +126,8 @@ func Test_NukeRunSimpleWithSecondPromptError(t *testing.T) {
 		return nil
 	})
 
-	resource.ClearRegistry()
-	resource.Register(&resource.Registration{
+	registry.ClearRegistry()
+	registry.Register(&registry.Registration{
 		Name:   "TestResourceSuccess",
 		Lister: &TestResourceSuccessLister{},
 	})
@@ -145,8 +146,8 @@ func Test_Nuke_Run_SimpleWithNoDryRun(t *testing.T) {
 	n.SetLogger(logrus.WithField("test", true))
 	n.SetRunSleep(time.Millisecond * 5)
 
-	resource.ClearRegistry()
-	resource.Register(&resource.Registration{
+	registry.ClearRegistry()
+	registry.Register(&registry.Registration{
 		Name:   "TestResourceSuccess",
 		Lister: &TestResourceSuccessLister{},
 	})
@@ -167,13 +168,13 @@ func Test_Nuke_Run_Failure(t *testing.T) {
 	n.SetLogger(logrus.WithField("test", true))
 	n.SetRunSleep(time.Millisecond * 5)
 
-	resource.ClearRegistry()
-	resource.Register(&resource.Registration{
+	registry.ClearRegistry()
+	registry.Register(&registry.Registration{
 		Name:   "TestResourceSuccess",
 		Lister: &TestResourceSuccessLister{},
 	})
 
-	resource.Register(&resource.Registration{
+	registry.Register(&registry.Registration{
 		Name:   "TestResourceFailure",
 		Lister: &TestResourceFailureLister{},
 	})
@@ -202,8 +203,8 @@ func Test_NukeRunWithMaxWaitRetries(t *testing.T) {
 	n.SetLogger(logrus.WithField("test", true))
 	n.SetRunSleep(time.Millisecond * 5)
 
-	resource.ClearRegistry()
-	resource.Register(&resource.Registration{
+	registry.ClearRegistry()
+	registry.Register(&registry.Registration{
 		Name:   "TestResourceSuccess",
 		Lister: &TestResourceWaitLister{},
 	})
@@ -249,12 +250,12 @@ func TestNuke_RunWithWaitOnDependencies(t *testing.T) {
 	n.SetLogger(logrus.WithField("test", true))
 	n.SetRunSleep(time.Millisecond * 5)
 
-	resource.ClearRegistry()
-	resource.Register(&resource.Registration{
+	registry.ClearRegistry()
+	registry.Register(&registry.Registration{
 		Name:   "TestResourceAlpha",
 		Lister: &TestResourceAlphaLister{},
 	})
-	resource.Register(&resource.Registration{
+	registry.Register(&registry.Registration{
 		Name:   "TestResourceBeta",
 		Lister: &TestResourceAlphaLister{},
 		DependsOn: []string{

--- a/pkg/nuke/nuke_test.go
+++ b/pkg/nuke/nuke_test.go
@@ -3,6 +3,7 @@ package nuke
 import (
 	"context"
 	"fmt"
+	"github.com/ekristen/libnuke/pkg/registry"
 	"io"
 	"os"
 	"strings"
@@ -34,7 +35,7 @@ var testParametersRemove = &Parameters{
 	NoDryRun:   true,
 }
 
-const testScope resource.Scope = "test"
+const testScope registry.Scope = "test"
 
 func Test_Nuke_Version(t *testing.T) {
 	n := New(testParameters, nil, nil)
@@ -228,9 +229,9 @@ func Test_Nuke_RegisterPrompt(t *testing.T) {
 // ------------------------------------------------------
 
 func Test_Nuke_Scan(t *testing.T) {
-	resource.ClearRegistry()
-	resource.Register(TestResourceRegistration)
-	resource.Register(&resource.Registration{
+	registry.ClearRegistry()
+	registry.Register(TestResourceRegistration)
+	registry.Register(&registry.Registration{
 		Name:  TestResourceType2,
 		Scope: "account",
 		Lister: TestResourceLister{
@@ -304,8 +305,8 @@ func Test_Nuke_HandleRemoveError(t *testing.T) {
 // ------------------------------------------------------------
 
 func Test_Nuke_Run(t *testing.T) {
-	resource.ClearRegistry()
-	resource.Register(TestResourceRegistration)
+	registry.ClearRegistry()
+	registry.Register(TestResourceRegistration)
 
 	p := &Parameters{
 		Force:      true,
@@ -331,8 +332,8 @@ func Test_Nuke_Run(t *testing.T) {
 }
 
 func Test_Nuke_Run_Error(t *testing.T) {
-	resource.ClearRegistry()
-	resource.Register(&resource.Registration{
+	registry.ClearRegistry()
+	registry.Register(&registry.Registration{
 		Name:  TestResourceType2,
 		Scope: "account",
 		Lister: TestResourceLister{
@@ -427,8 +428,8 @@ func Test_Nuke_Run_ItemStateHold(t *testing.T) {
 	n.SetLogger(logrus.WithField("test", true))
 	n.SetRunSleep(time.Millisecond * 5)
 
-	resource.ClearRegistry()
-	resource.Register(&resource.Registration{
+	registry.ClearRegistry()
+	registry.Register(&registry.Registration{
 		Name:   "TestResource4",
 		Scope:  testScope,
 		Lister: &TestResource4Lister{},

--- a/pkg/nuke/nuke_test.go
+++ b/pkg/nuke/nuke_test.go
@@ -3,7 +3,6 @@ package nuke
 import (
 	"context"
 	"fmt"
-	"github.com/ekristen/libnuke/pkg/registry"
 	"io"
 	"os"
 	"strings"
@@ -16,6 +15,7 @@ import (
 	liberrors "github.com/ekristen/libnuke/pkg/errors"
 
 	"github.com/ekristen/libnuke/pkg/queue"
+	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
 	"github.com/ekristen/libnuke/pkg/scanner"
 	"github.com/ekristen/libnuke/pkg/settings"

--- a/pkg/nuke/testsuite_test.go
+++ b/pkg/nuke/testsuite_test.go
@@ -3,13 +3,13 @@ package nuke
 import (
 	"context"
 	"fmt"
-	"github.com/ekristen/libnuke/pkg/registry"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ekristen/libnuke/pkg/errors"
+	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
 	"github.com/ekristen/libnuke/pkg/settings"
 	"github.com/ekristen/libnuke/pkg/types"

--- a/pkg/nuke/testsuite_test.go
+++ b/pkg/nuke/testsuite_test.go
@@ -3,6 +3,7 @@ package nuke
 import (
 	"context"
 	"fmt"
+	"github.com/ekristen/libnuke/pkg/registry"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -33,14 +34,14 @@ func (h *TestGlobalHook) Fire(e *logrus.Entry) error {
 
 var (
 	TestResourceType         = "testResourceType"
-	TestResourceRegistration = &resource.Registration{
+	TestResourceRegistration = &registry.Registration{
 		Name:   TestResourceType,
 		Scope:  "account",
 		Lister: &TestResourceLister{},
 	}
 
 	TestResourceType2         = "testResourceType2"
-	TestResourceRegistration2 = &resource.Registration{
+	TestResourceRegistration2 = &registry.Registration{
 		Name:   TestResourceType2,
 		Scope:  "account",
 		Lister: &TestResourceLister{},

--- a/pkg/queue/item.go
+++ b/pkg/queue/item.go
@@ -3,9 +3,9 @@ package queue
 import (
 	"context"
 	"fmt"
-	"github.com/ekristen/libnuke/pkg/registry"
 
 	"github.com/ekristen/libnuke/pkg/log"
+	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
 )
 

--- a/pkg/queue/item.go
+++ b/pkg/queue/item.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"context"
 	"fmt"
+	"github.com/ekristen/libnuke/pkg/registry"
 
 	"github.com/ekristen/libnuke/pkg/log"
 	"github.com/ekristen/libnuke/pkg/resource"
@@ -54,7 +55,7 @@ func (i *Item) GetReason() string {
 // List calls the List method for the lister for the Type that belongs to the Item which returns
 // a list of resources or an error. This primarily is used for the HandleWait function.
 func (i *Item) List(ctx context.Context, opts interface{}) ([]resource.Resource, error) {
-	return resource.GetLister(i.Type).List(ctx, opts)
+	return registry.GetLister(i.Type).List(ctx, opts)
 }
 
 // GetProperty retrieves the string value of a property on the Item's Resource if it exists.

--- a/pkg/queue/item_test.go
+++ b/pkg/queue/item_test.go
@@ -2,11 +2,11 @@ package queue
 
 import (
 	"context"
-	"github.com/ekristen/libnuke/pkg/registry"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
 	"github.com/ekristen/libnuke/pkg/types"
 )

--- a/pkg/queue/item_test.go
+++ b/pkg/queue/item_test.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"context"
+	"github.com/ekristen/libnuke/pkg/registry"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -66,8 +67,8 @@ func Test_Item(t *testing.T) {
 }
 
 func Test_ItemList(t *testing.T) {
-	resource.ClearRegistry()
-	resource.Register(&resource.Registration{
+	registry.ClearRegistry()
+	registry.Register(&registry.Registration{
 		Name:   "TestResource",
 		Lister: &TestItemResourceLister{},
 	})

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,3 +1,5 @@
+// Package registry provides a way to register resources and their listers and obtain them after the fact. The registry
+// is currently deeply embedded with the other packages and how they access specific aspects of a resource.
 package registry
 
 import (

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,4 +1,4 @@
-package resource
+package registry
 
 import (
 	"context"
@@ -6,6 +6,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stevenle/topsort"
+
+	"github.com/ekristen/libnuke/pkg/resource"
 )
 
 // Scope is a string in which resources are grouped against, this is meant for upstream tools to define their
@@ -75,7 +77,7 @@ type Registration struct {
 
 // Lister is an interface that represents a resource that can be listed
 type Lister interface {
-	List(ctx context.Context, opts interface{}) ([]Resource, error)
+	List(ctx context.Context, opts interface{}) ([]resource.Resource, error)
 }
 
 // RegisterOption is a function that can be used to manipulate the lister for a given resource type at

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -1,7 +1,8 @@
-package resource
+package registry
 
 import (
 	"context"
+	"github.com/ekristen/libnuke/pkg/resource"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,7 +10,9 @@ import (
 
 type TestLister struct{}
 
-func (l TestLister) List(_ context.Context, o interface{}) ([]Resource, error) { return nil, nil }
+func (l TestLister) List(_ context.Context, o interface{}) ([]resource.Resource, error) {
+	return nil, nil
+}
 
 func Test_RegisterNoScope(t *testing.T) {
 	ClearRegistry()

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -2,10 +2,11 @@ package registry
 
 import (
 	"context"
-	"github.com/ekristen/libnuke/pkg/resource"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ekristen/libnuke/pkg/resource"
 )
 
 type TestLister struct{}

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ekristen/libnuke/pkg/registry"
 
 	"runtime/debug"
 
@@ -17,6 +16,7 @@ import (
 	liberrors "github.com/ekristen/libnuke/pkg/errors"
 
 	"github.com/ekristen/libnuke/pkg/queue"
+	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
 	"github.com/ekristen/libnuke/pkg/utils"
 )

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/ekristen/libnuke/pkg/registry"
 
 	"runtime/debug"
 
@@ -109,7 +110,7 @@ func (s *Scanner) list(ctx context.Context, owner, resourceType string, opts int
 
 	defer s.semaphore.Release(1)
 
-	lister := resource.GetLister(resourceType)
+	lister := registry.GetLister(resourceType)
 	var rs []resource.Resource
 
 	if lister == nil {

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -1,3 +1,6 @@
+// Package scanner provides a mechanism for scanning resources and adding them to the item queue for processing. The
+// scope of the scanner is determined by the resource types that are passed to it. The scanner will then run the lister
+// for each resource type and add the resources to the item queue for processing.
 package scanner
 
 import (

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -2,7 +2,6 @@ package scanner
 
 import (
 	"context"
-	"github.com/ekristen/libnuke/pkg/registry"
 	"strings"
 	"sync"
 	"testing"
@@ -10,6 +9,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/ekristen/libnuke/pkg/registry"
 )
 
 func Test_NewScannerWithMorphOpts(t *testing.T) {

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"context"
+	"github.com/ekristen/libnuke/pkg/registry"
 	"strings"
 	"sync"
 	"testing"
@@ -9,13 +10,11 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/ekristen/libnuke/pkg/resource"
 )
 
 func Test_NewScannerWithMorphOpts(t *testing.T) {
-	resource.ClearRegistry()
-	resource.Register(testResourceRegistration)
+	registry.ClearRegistry()
+	registry.Register(testResourceRegistration)
 
 	opts := TestOpts{
 		SessionOne: "testing",
@@ -45,8 +44,8 @@ func Test_NewScannerWithMorphOpts(t *testing.T) {
 }
 
 func Test_NewScannerWithDuplicateMorphOpts(t *testing.T) {
-	resource.ClearRegistry()
-	resource.Register(testResourceRegistration)
+	registry.ClearRegistry()
+	registry.Register(testResourceRegistration)
 
 	opts := TestOpts{
 		SessionOne: "testing",
@@ -67,11 +66,11 @@ func Test_NewScannerWithDuplicateMorphOpts(t *testing.T) {
 }
 
 func Test_NewScannerWithResourceListerError(t *testing.T) {
-	resource.ClearRegistry()
+	registry.ClearRegistry()
 	logrus.AddHook(&TestGlobalHook{
 		t: t,
 		tf: func(t *testing.T, e *logrus.Entry) {
-			if strings.HasSuffix(e.Caller.File, "pkg/resource/registry.go") {
+			if strings.HasSuffix(e.Caller.File, "pkg/registry/registry.go") {
 				return
 			}
 
@@ -80,7 +79,7 @@ func Test_NewScannerWithResourceListerError(t *testing.T) {
 	})
 	defer logrus.StandardLogger().ReplaceHooks(make(logrus.LevelHooks))
 
-	resource.Register(testResourceRegistration)
+	registry.Register(testResourceRegistration)
 
 	opts := TestOpts{
 		SessionOne: "testing",
@@ -95,11 +94,11 @@ func Test_NewScannerWithResourceListerError(t *testing.T) {
 }
 
 func Test_NewScannerWithResourceListerErrorSkip(t *testing.T) {
-	resource.ClearRegistry()
+	registry.ClearRegistry()
 	logrus.AddHook(&TestGlobalHook{
 		t: t,
 		tf: func(t *testing.T, e *logrus.Entry) {
-			if strings.HasSuffix(e.Caller.File, "pkg/resource/registry.go") {
+			if strings.HasSuffix(e.Caller.File, "pkg/registry/registry.go") {
 				assert.Equal(t, logrus.TraceLevel, e.Level)
 				assert.Equal(t, "registered resource lister", e.Message)
 				return
@@ -113,7 +112,7 @@ func Test_NewScannerWithResourceListerErrorSkip(t *testing.T) {
 	})
 	defer logrus.StandardLogger().ReplaceHooks(make(logrus.LevelHooks))
 
-	resource.Register(testResourceRegistration)
+	registry.Register(testResourceRegistration)
 
 	opts := TestOpts{
 		SessionOne:     "testing",
@@ -128,11 +127,11 @@ func Test_NewScannerWithResourceListerErrorSkip(t *testing.T) {
 }
 
 func Test_NewScannerWithResourceListerErrorUnknownEndpoint(t *testing.T) {
-	resource.ClearRegistry()
+	registry.ClearRegistry()
 	logrus.AddHook(&TestGlobalHook{
 		t: t,
 		tf: func(t *testing.T, e *logrus.Entry) {
-			if strings.HasSuffix(e.Caller.File, "pkg/resource/registry.go") {
+			if strings.HasSuffix(e.Caller.File, "pkg/registry/registry.go") {
 				assert.Equal(t, logrus.TraceLevel, e.Level)
 				assert.Equal(t, "registered resource lister", e.Message)
 				return
@@ -146,7 +145,7 @@ func Test_NewScannerWithResourceListerErrorUnknownEndpoint(t *testing.T) {
 	})
 	defer logrus.StandardLogger().ReplaceHooks(make(logrus.LevelHooks))
 
-	resource.Register(testResourceRegistration)
+	registry.Register(testResourceRegistration)
 
 	opts := TestOpts{
 		SessionOne:         "testing",
@@ -175,8 +174,8 @@ func TestRunSemaphoreFirstAcquireError(t *testing.T) {
 }
 
 func TestRunSemaphoreSecondAcquireError(t *testing.T) {
-	resource.ClearRegistry()
-	resource.Register(testResourceRegistration)
+	registry.ClearRegistry()
+	registry.Register(testResourceRegistration)
 	// Create a new scanner
 	scanner := New("owner", []string{testResourceType}, TestOpts{
 		Sleep: 45 * time.Second,
@@ -198,28 +197,28 @@ func Test_NewScannerWithResourceListerPanic(t *testing.T) {
 
 	panicCaught := false
 
-	resource.ClearRegistry()
+	registry.ClearRegistry()
 	logrus.AddHook(&TestGlobalHook{
 		t: t,
 		tf: func(t *testing.T, e *logrus.Entry) {
-			if strings.HasSuffix(e.Caller.File, "pkg/resource/registry.go") {
-				assert.Equal(t, logrus.TraceLevel, e.Level)
+			if strings.HasSuffix(e.Caller.File, "pkg/registry/registry.go") {
 				assert.Equal(t, "registered resource lister", e.Message)
 				wg.Done()
 				return
 			}
 
-			if strings.HasSuffix(e.Caller.File, "pkg/scanner/scanner.go") && e.Caller.Line == 106 {
+			if strings.HasSuffix(e.Caller.File, "pkg/scanner/scanner.go") && e.Caller.Line == 107 {
 				assert.Contains(t, e.Message, "Listing testResourceType failed")
 				assert.Contains(t, e.Message, "panic error for testing")
 				logrus.StandardLogger().ReplaceHooks(make(logrus.LevelHooks))
 				panicCaught = true
 				wg.Done()
+				return
 			}
 		},
 	})
 
-	resource.Register(testResourceRegistration)
+	registry.Register(testResourceRegistration)
 
 	opts := TestOpts{
 		SessionOne: "testing",

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -208,7 +208,7 @@ func Test_NewScannerWithResourceListerPanic(t *testing.T) {
 				return
 			}
 
-			if strings.HasSuffix(e.Caller.File, "pkg/scanner/scanner.go") && e.Caller.Line == 107 {
+			if strings.HasSuffix(e.Caller.File, "pkg/scanner/scanner.go") && e.Caller.Line == 110 {
 				assert.Contains(t, e.Message, "Listing testResourceType failed")
 				assert.Contains(t, e.Message, "panic error for testing")
 				logrus.StandardLogger().ReplaceHooks(make(logrus.LevelHooks))

--- a/pkg/scanner/testsuite_test.go
+++ b/pkg/scanner/testsuite_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/ekristen/libnuke/pkg/registry"
 	"io"
 	"testing"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ekristen/libnuke/pkg/errors"
+	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
 	"github.com/ekristen/libnuke/pkg/settings"
 	"github.com/ekristen/libnuke/pkg/types"

--- a/pkg/scanner/testsuite_test.go
+++ b/pkg/scanner/testsuite_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/ekristen/libnuke/pkg/registry"
 	"io"
 	"testing"
 	"time"
@@ -27,7 +28,7 @@ func init() {
 
 var (
 	testResourceType         = "testResourceType"
-	testResourceRegistration = &resource.Registration{
+	testResourceRegistration = &registry.Registration{
 		Name:   testResourceType,
 		Scope:  "account",
 		Lister: &TestResourceLister{},


### PR DESCRIPTION
This is the first step, ultimately I'd like to adopt the prometheus go client model of a default registry and separate registries, however the registry model is so embedded in the code, it'll take a while to pull it all out.