### PR TITLE
fix: do not throw error on property not supported, log and continue

### DIFF
--- a/pkg/nuke/nuke.go
+++ b/pkg/nuke/nuke.go
@@ -464,7 +464,8 @@ func (n *Nuke) Filter(item *queue.Item) error {
 
 		prop, err := item.GetProperty(f.Property)
 		if err != nil {
-			return err
+			log.WithError(err).Warnf("unable to get property: %s", f.Property)
+			continue
 		}
 
 		log.Tracef("property: %s", prop)

--- a/pkg/nuke/nuke_filter_test.go
+++ b/pkg/nuke/nuke_filter_test.go
@@ -2,6 +2,9 @@ package nuke
 
 import (
 	"context"
+	"flag"
+	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,6 +18,14 @@ import (
 	"github.com/ekristen/libnuke/pkg/scanner"
 	"github.com/ekristen/libnuke/pkg/types"
 )
+
+func init() {
+	if flag.Lookup("test.v") != nil {
+		logrus.SetOutput(io.Discard)
+	}
+	logrus.SetLevel(logrus.TraceLevel)
+	logrus.SetReportCaller(true)
+}
 
 func Test_NukeFiltersBad(t *testing.T) {
 	filters := filter.Filters{
@@ -135,6 +146,20 @@ func Test_Nuke_Filters_NoMatch(t *testing.T) {
 }
 
 func Test_Nuke_Filters_ErrorCustomProps(t *testing.T) {
+	logrus.AddHook(&TestGlobalHook{
+		t: t,
+		tf: func(t *testing.T, e *logrus.Entry) {
+			if strings.HasSuffix(e.Caller.File, "pkg/nuke/nuke.go") {
+				return
+			}
+
+			if e.Caller.Line == 467 {
+				assert.Equal(t, "*nuke.TestResource does not support custom properties", e.Message)
+			}
+		},
+	})
+	defer logrus.StandardLogger().ReplaceHooks(make(logrus.LevelHooks))
+
 	registry.ClearRegistry()
 	registry.Register(TestResourceRegistration)
 
@@ -161,8 +186,7 @@ func Test_Nuke_Filters_ErrorCustomProps(t *testing.T) {
 	assert.NoError(t, sErr)
 
 	err := n.Scan(context.TODO())
-	assert.Error(t, err)
-	assert.Equal(t, "*nuke.TestResource does not support custom properties", err.Error())
+	assert.NoError(t, err)
 }
 
 type TestResourceFilter struct {


### PR DESCRIPTION
This fixes an parity issue with the original aws nuke code where if a property wasn't supported it would log and continue.

Reference: https://github.com/ekristen/aws-nuke/issues/81