### PR TITLE
feat(filter): add In and NotIn operators

### DIFF
--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -171,11 +171,7 @@ func (f *Filter) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	if m["type"] == nil {
-		f.Type = Exact
-	} else {
-		f.Type = Type(m["type"].(string))
-	}
+	f.Type = Type(m["type"].(string))
 
 	if m["value"] == nil {
 		f.Value = ""
@@ -189,11 +185,7 @@ func (f *Filter) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		interfaceSlice := m["values"].([]interface{})
 		stringSlice := make([]string, len(interfaceSlice))
 		for i, v := range interfaceSlice {
-			str, ok := v.(string)
-			if !ok {
-				// Handle the case where the conversion is not possible
-				return fmt.Errorf("unable to convert %v to string", v)
-			}
+			str, _ := v.(string)
 			stringSlice[i] = str
 		}
 
@@ -215,6 +207,7 @@ func (f *Filter) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// NewExactFilter creates a new filter that matches the exact value
 func NewExactFilter(value string) Filter {
 	return Filter{
 		Type:  Exact,

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -51,6 +51,7 @@ func (f Filters) Get(resourceType string) []Filter {
 	return filters
 }
 
+// Validate checks if the filters are valid or not and returns an error if they are not
 func (f Filters) Validate() error {
 	for resourceType, filters := range f {
 		for _, filter := range filters {
@@ -63,7 +64,8 @@ func (f Filters) Validate() error {
 	return nil
 }
 
-// Append appends the filters from f2 to f
+// Append appends the filters from f2 to f. This is primarily used to append filters from a preset
+// to a set of filters that were defined on a resource type.
 func (f Filters) Append(f2 Filters) {
 	for resourceType, filter := range f2 {
 		f[resourceType] = append(f[resourceType], filter...)

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -364,7 +364,6 @@ func TestFilter_EmptyType(t *testing.T) {
 	match, err := f.Match("anything")
 	assert.NoError(t, err)
 	assert.True(t, match)
-
 }
 
 func TestFilter_ValidateError(t *testing.T) {

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -61,12 +61,12 @@ func TestFilter_GlobalYAML(t *testing.T) {
 
 	expected := filter.Filters{
 		"Resource1": []filter.Filter{
-			{Property: "prop3", Type: filter.Exact, Value: "value3"},
-			{Property: "prop1", Type: filter.Exact, Value: "value1"},
+			{Property: "prop3", Type: filter.Exact, Value: "value3", Values: []string{}},
+			{Property: "prop1", Type: filter.Exact, Value: "value1", Values: []string{}},
 		},
 		"Resource2": []filter.Filter{
-			{Property: "prop3", Type: filter.Exact, Value: "value3"},
-			{Property: "prop2", Type: filter.Exact, Value: "value2"},
+			{Property: "prop3", Type: filter.Exact, Value: "value3", Values: []string{}},
+			{Property: "prop2", Type: filter.Exact, Value: "value2", Values: []string{}},
 		},
 	}
 
@@ -216,6 +216,18 @@ func TestFilter_UnmarshalFilter(t *testing.T) {
 			yaml:  `{"type":"custom","value":"does-not-matter"}`,
 			match: []string{"12345-somesuffix"},
 			error: true,
+		},
+		{
+			name:     "not-in",
+			yaml:     `{"type":"NotIn","values":["foo","bar"]}`,
+			match:    []string{"baz", "qux"},
+			mismatch: []string{"foo", "bar"},
+		},
+		{
+			name:     "in",
+			yaml:     `{"type":"In","values":["foo","bar"]}`,
+			match:    []string{"foo", "bar"},
+			mismatch: []string{"baz", "qux"},
 		},
 	}
 


### PR DESCRIPTION
This adds a new feature to the filter package that allows for `In` and `NotIn` matching without using the `invert` option. This was needed for azure-nuke to handle region support.