### PR TITLE
feat: properties from struct

### DIFF
--- a/pkg/docs/generate.go
+++ b/pkg/docs/generate.go
@@ -1,0 +1,75 @@
+package docs
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+func GeneratePropertiesMap(data interface{}) map[string]string {
+	properties := map[string]string{}
+
+	v := reflect.ValueOf(data)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	t := v.Type()
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+
+		if !field.IsExported() {
+			continue
+		}
+
+		propertyTag := field.Tag.Get("property")
+		options := strings.Split(propertyTag, ",")
+		name := field.Name
+		prefix := ""
+
+		if options[0] == "-" {
+			continue
+		}
+
+		for _, option := range options {
+			parts := strings.Split(option, "=")
+			if len(parts) != 2 {
+				continue
+			}
+			switch parts[0] {
+			case "name":
+				name = parts[1]
+			case "prefix":
+				prefix = parts[1]
+			}
+		}
+
+		if prefix != "" && name != "Tags" {
+			name = fmt.Sprintf("%s:%s", prefix, name)
+		}
+
+		descriptionTag := field.Tag.Get("description")
+
+		if name == "Tags" {
+			originalName := name
+			name = "tag:<key>:"
+			tagPrefix := "tag:"
+			if prefix != "" {
+				tagPrefix = fmt.Sprintf("tag:%s:", prefix)
+			}
+
+			descriptionTag = fmt.Sprintf(
+				"This resource has tags with property `%s`. These are key/value pairs that are\n\t"+
+					"added as their own property with the prefix of `%s` (e.g. [%sexample: \"value\"]) ",
+				originalName, tagPrefix, tagPrefix)
+
+			if prefix != "" {
+				name = fmt.Sprintf("tag:%s:<key>:", prefix)
+			}
+		}
+
+		properties[name] = fmt.Sprintf("%s", descriptionTag)
+	}
+
+	return properties
+}

--- a/pkg/docs/generate.go
+++ b/pkg/docs/generate.go
@@ -68,7 +68,7 @@ func GeneratePropertiesMap(data interface{}) map[string]string {
 			}
 		}
 
-		properties[name] = fmt.Sprintf("%s", descriptionTag)
+		properties[name] = descriptionTag
 	}
 
 	return properties

--- a/pkg/docs/generate_test.go
+++ b/pkg/docs/generate_test.go
@@ -1,8 +1,9 @@
 package docs
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGenerateProperties(t *testing.T) {

--- a/pkg/docs/generate_test.go
+++ b/pkg/docs/generate_test.go
@@ -24,7 +24,7 @@ func TestGenerateProperties(t *testing.T) {
 		Name    string `description:"The name of the resource"`
 		Ignore  string `property:"-"`
 		Example string `description:"A property rename" property:"name=Delta"`
-		skipped string
+		skipped string //nolint:unused
 	}
 
 	cases := []struct {

--- a/pkg/docs/generate_test.go
+++ b/pkg/docs/generate_test.go
@@ -1,0 +1,57 @@
+package docs
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGenerateProperties(t *testing.T) {
+	type TestResource1 struct {
+		Name   string            `description:"The name of the resource"`
+		Region *string           `description:"The region in which the resource resides"`
+		VpcID  string            `description:"The VPC ID of the resource" property:"prefix=vpc"`
+		Tags   map[string]string `description:"The tags associated with the resource"`
+	}
+
+	type TestResource2 struct {
+		Name   string            `description:"The name of the resource"`
+		Region *string           `description:"The region in which the resource resides"`
+		Tags   map[string]string `description:"The tags associated with the resource" property:"prefix=ee"`
+	}
+
+	cases := []struct {
+		name string
+		in   interface{}
+		want map[string]string
+	}{
+		{
+			name: "TestResource1",
+			in:   TestResource1{},
+			want: map[string]string{
+				"Name":      "The name of the resource",
+				"Region":    "The region in which the resource resides",
+				"vpc:VpcID": "The VPC ID of the resource",
+				"tag:<key>:": "This resource has tags with property `Tags`. These are key/value pairs that are\n\t" +
+					"added as their own property with the prefix of `tag:` (e.g. [tag:example: \"value\"]) ",
+			},
+		},
+		{
+			name: "TestResource2",
+			in:   TestResource2{},
+			want: map[string]string{
+				"Name":   "The name of the resource",
+				"Region": "The region in which the resource resides",
+				"tag:ee:<key>:": "This resource has tags with property `Tags`. These are key/value pairs that are\n\t" +
+					"added as their own property with the prefix of `tag:ee:" +
+					"` (e.g. [tag:ee:example: \"value\"]) ",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			have := GeneratePropertiesMap(c.in)
+			assert.Equal(t, c.want, have)
+		})
+	}
+}

--- a/pkg/docs/generate_test.go
+++ b/pkg/docs/generate_test.go
@@ -20,6 +20,13 @@ func TestGenerateProperties(t *testing.T) {
 		Tags   map[string]string `description:"The tags associated with the resource" property:"prefix=ee"`
 	}
 
+	type TestResource3 struct {
+		Name    string `description:"The name of the resource"`
+		Ignore  string `property:"-"`
+		Example string `description:"A property rename" property:"name=Delta"`
+		skipped string
+	}
+
 	cases := []struct {
 		name string
 		in   interface{}
@@ -45,6 +52,22 @@ func TestGenerateProperties(t *testing.T) {
 				"tag:ee:<key>:": "This resource has tags with property `Tags`. These are key/value pairs that are\n\t" +
 					"added as their own property with the prefix of `tag:ee:" +
 					"` (e.g. [tag:ee:example: \"value\"]) ",
+			},
+		},
+		{
+			name: "TestResource3",
+			in:   TestResource3{},
+			want: map[string]string{
+				"Name":  "The name of the resource",
+				"Delta": "A property rename",
+			},
+		},
+		{
+			name: "PointerTestResource3",
+			in:   &TestResource3{},
+			want: map[string]string{
+				"Name":  "The name of the resource",
+				"Delta": "A property rename",
 			},
 		},
 	}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -120,6 +120,11 @@ func Register(r *Registration) {
 	}
 }
 
+// GetRegistrations returns all registrations
+func GetRegistrations() Registrations {
+	return registrations
+}
+
 // ClearRegistry clears the registry of all registrations
 // Designed for use for unit tests, not for production code. Only use if you know what you are doing.
 func ClearRegistry() {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -48,6 +48,12 @@ type Registration struct {
 	// different levels, whereas AWS has simply Account level.
 	Scope Scope
 
+	// Resource is the resource type that the lister is going to list. This is a struct that implements the Resource
+	// interface. This is primarily used to generate documentation by parsing the structs properties and generating
+	// markdown documentation.
+	// Note: it is a interface{} because we are going to inspect it, we do not need to actually call any methods on it.
+	Resource interface{}
+
 	// Lister is the lister for the resource type, it is a struct with a method called List that returns a slice
 	// of resources. The lister is responsible for filtering out any resources that should not be deleted because they
 	// are ineligible for deletion. For example, built in resources that cannot be deleted.

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -140,3 +140,16 @@ func Test_RegisterResourcesWithAlternative(t *testing.T) {
 	assert.Len(t, deprecatedMapping, 1)
 	assert.Equal(t, "test2", deprecatedMapping["test"])
 }
+
+func Test_GetRegistrations(t *testing.T) {
+	ClearRegistry()
+
+	Register(&Registration{
+		Name:   "test",
+		Scope:  "test",
+		Lister: TestLister{},
+	})
+
+	regs := GetRegistrations()
+	assert.Len(t, regs, 1)
+}

--- a/pkg/types/properties.go
+++ b/pkg/types/properties.go
@@ -6,16 +6,20 @@ import (
 	"strings"
 )
 
+// Properties is a map of key-value pairs.
 type Properties map[string]string
 
+// NewProperties creates a new Properties map.
 func NewProperties() Properties {
 	return make(Properties)
 }
 
+// NewPropertiesFromStruct creates a new Properties map from a struct.
 func NewPropertiesFromStruct(data interface{}) Properties {
 	return NewProperties().SetFromStruct(data)
 }
 
+// String returns a string representation of the Properties map.
 func (p Properties) String() string {
 	var parts []string
 	for k, v := range p {
@@ -25,6 +29,17 @@ func (p Properties) String() string {
 	return fmt.Sprintf("[%s]", strings.Join(parts, ", "))
 }
 
+// Get returns the value of a key in the Properties map.
+func (p Properties) Get(key string) string {
+	value, ok := p[key]
+	if !ok {
+		return ""
+	}
+
+	return value
+}
+
+// Set sets a key-value pair in the Properties map.
 func (p Properties) Set(key string, value interface{}) Properties {
 	if value == nil {
 		return p
@@ -62,10 +77,28 @@ func (p Properties) Set(key string, value interface{}) Properties {
 	return p
 }
 
+// SetWithPrefix sets a key-value pair in the Properties map with a prefix.
+func (p Properties) SetWithPrefix(prefix, key string, value interface{}) Properties {
+	key = strings.TrimSpace(key)
+	prefix = strings.TrimSpace(prefix)
+
+	if key == "" {
+		return p
+	}
+
+	if prefix != "" {
+		key = fmt.Sprintf("%s:%s", prefix, key)
+	}
+
+	return p.Set(key, value)
+}
+
+// SetTag sets a tag key-value pair in the Properties map.
 func (p Properties) SetTag(tagKey *string, tagValue interface{}) Properties {
 	return p.SetTagWithPrefix("", tagKey, tagValue)
 }
 
+// SetTagWithPrefix sets a tag key-value pair in the Properties map with a prefix.
 func (p Properties) SetTagWithPrefix(prefix string, tagKey *string, tagValue interface{}) Properties {
 	if tagKey == nil {
 		return p
@@ -87,30 +120,7 @@ func (p Properties) SetTagWithPrefix(prefix string, tagKey *string, tagValue int
 	return p.Set(keyStr, tagValue)
 }
 
-func (p Properties) SetWithPrefix(prefix, key string, value interface{}) Properties {
-	key = strings.TrimSpace(key)
-	prefix = strings.TrimSpace(prefix)
-
-	if key == "" {
-		return p
-	}
-
-	if prefix != "" {
-		key = fmt.Sprintf("%s:%s", prefix, key)
-	}
-
-	return p.Set(key, value)
-}
-
-func (p Properties) Get(key string) string {
-	value, ok := p[key]
-	if !ok {
-		return ""
-	}
-
-	return value
-}
-
+// Equals compares two Properties maps.
 func (p Properties) Equals(o Properties) bool {
 	if p == nil && o == nil {
 		return true
@@ -138,6 +148,7 @@ func (p Properties) Equals(o Properties) bool {
 	return true
 }
 
+// SetFromStruct sets the Properties map from a struct by reading the structs fields
 func (p Properties) SetFromStruct(data interface{}) Properties { //nolint:funlen,gocyclo
 	v := reflect.ValueOf(data)
 	t := reflect.TypeOf(data)

--- a/pkg/types/properties.go
+++ b/pkg/types/properties.go
@@ -240,7 +240,7 @@ func (p Properties) SetFromStruct(data interface{}) Properties { //nolint:funlen
 				}
 			}
 		default:
-			p.SetWithPrefix(prefix, field.Name, value.Interface())
+			p.SetWithPrefix(prefix, name, value.Interface())
 		}
 	}
 

--- a/pkg/types/properties.go
+++ b/pkg/types/properties.go
@@ -200,6 +200,12 @@ func (p Properties) SetFromStruct(data interface{}) Properties { //nolint:funlen
 		case reflect.Map:
 			for _, key := range value.MapKeys() {
 				val := value.MapIndex(key)
+				if key.Kind() == reflect.Ptr {
+					key = key.Elem()
+				}
+				if val.Kind() == reflect.Ptr {
+					val = val.Elem()
+				}
 				name = key.String()
 				p.SetTagWithPrefix(prefix, &name, val.Interface())
 			}

--- a/pkg/types/properties.go
+++ b/pkg/types/properties.go
@@ -151,7 +151,10 @@ func (p Properties) Equals(o Properties) bool {
 // SetFromStruct sets the Properties map from a struct by reading the structs fields
 func (p Properties) SetFromStruct(data interface{}) Properties { //nolint:funlen,gocyclo
 	v := reflect.ValueOf(data)
-	t := reflect.TypeOf(data)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	t := v.Type()
 
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)

--- a/pkg/types/properties.go
+++ b/pkg/types/properties.go
@@ -160,6 +160,10 @@ func (p Properties) SetFromStruct(data interface{}) Properties { //nolint:funlen
 		field := t.Field(i)
 		value := v.Field(i)
 
+		if !field.IsExported() {
+			continue
+		}
+
 		isSet := false
 
 		switch value.Kind() {

--- a/pkg/types/properties.go
+++ b/pkg/types/properties.go
@@ -239,16 +239,8 @@ func (p Properties) SetFromStruct(data interface{}) Properties { //nolint:funlen
 					}
 				}
 			}
-		case reflect.Int:
-			p.SetWithPrefix(prefix, field.Name, value.Interface().(int))
-		case reflect.Int64:
-			p.SetWithPrefix(prefix, field.Name, value.Interface().(int64))
-		case reflect.String:
-			p.SetWithPrefix(prefix, field.Name, value.Interface().(string))
-		case reflect.Bool:
-			p.SetWithPrefix(prefix, field.Name, value.Interface().(bool))
 		default:
-			panic(fmt.Errorf("unsupported type %v -> %v", value.Kind(), value.Interface()))
+			p.SetWithPrefix(prefix, field.Name, value.Interface())
 		}
 	}
 

--- a/pkg/types/properties.go
+++ b/pkg/types/properties.go
@@ -12,6 +12,10 @@ func NewProperties() Properties {
 	return make(Properties)
 }
 
+func NewPropertiesFromStruct(data interface{}) Properties {
+	return NewProperties().SetFromStruct(data)
+}
+
 func (p Properties) String() string {
 	var parts []string
 	for k, v := range p {
@@ -134,9 +138,9 @@ func (p Properties) Equals(o Properties) bool {
 	return true
 }
 
-func (p Properties) SetFromStruct(er interface{}) Properties {
-	v := reflect.ValueOf(er)
-	t := reflect.TypeOf(er)
+func (p Properties) SetFromStruct(data interface{}) Properties {
+	v := reflect.ValueOf(data)
+	t := reflect.TypeOf(data)
 
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)

--- a/pkg/types/properties.go
+++ b/pkg/types/properties.go
@@ -138,7 +138,7 @@ func (p Properties) Equals(o Properties) bool {
 	return true
 }
 
-func (p Properties) SetFromStruct(data interface{}) Properties {
+func (p Properties) SetFromStruct(data interface{}) Properties { //nolint:funlen,gocyclo
 	v := reflect.ValueOf(data)
 	t := reflect.TypeOf(data)
 
@@ -229,9 +229,4 @@ func (p Properties) SetFromStruct(data interface{}) Properties {
 	}
 
 	return p
-}
-
-type KeyValue struct {
-	Key   *string
-	Value *string
 }

--- a/pkg/types/properties_test.go
+++ b/pkg/types/properties_test.go
@@ -412,6 +412,11 @@ func TestPropertiesSetFromStruct(t *testing.T) {
 			want: types.NewProperties().Set("Age", 42).Set("Name", "Alice"),
 		},
 		{
+			name: "simple-pointer",
+			s:    &testStruct{Name: "Alice", Age: 42},
+			want: types.NewProperties().Set("Age", 42).Set("Name", "Alice"),
+		},
+		{
 			name: "complex",
 			s: testStruct3{
 				Name: "Alice",

--- a/pkg/types/properties_test.go
+++ b/pkg/types/properties_test.go
@@ -534,7 +534,6 @@ func BenchmarkNewPropertiesFromStruct_Complex(b *testing.B) {
 			},
 		})
 	}
-
 }
 
 func getString(value interface{}) string {

--- a/pkg/types/properties_test.go
+++ b/pkg/types/properties_test.go
@@ -378,8 +378,9 @@ func TestPropertiesSetFromStruct(t *testing.T) {
 	}
 
 	type testStruct6 struct {
-		Name string
-		Tags map[*string]*string
+		Name       string
+		Tags       map[*string]*string
+		unexported string
 	}
 
 	cases := []struct {
@@ -474,8 +475,9 @@ func TestPropertiesSetFromStruct(t *testing.T) {
 		{
 			name: "tags-pointer-pointer",
 			s: testStruct6{
-				Name: "Alice",
-				Tags: map[*string]*string{ptr.String("key"): ptr.String("value")},
+				Name:       "Alice",
+				Tags:       map[*string]*string{ptr.String("key"): ptr.String("value")},
+				unexported: "hidden",
 			},
 			want: types.NewProperties().Set("Name", "Alice").SetTag(ptr.String("key"), "value"),
 		},

--- a/pkg/types/properties_test.go
+++ b/pkg/types/properties_test.go
@@ -442,6 +442,11 @@ func TestPropertiesSetFromStruct(t *testing.T) {
 			want:  types.NewProperties(),
 			error: true,
 		},
+		{
+			name: "new-properties-from-struct",
+			s:    testStruct3{Name: "testing"},
+			want: types.NewPropertiesFromStruct(testStruct3{Name: "testing"}),
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/types/properties_test.go
+++ b/pkg/types/properties_test.go
@@ -441,8 +441,8 @@ func TestPropertiesSetFromStruct(t *testing.T) {
 				Tags:   &map[string]string{"key": "value"},
 			},
 			want: types.NewProperties().
-				Set("Name", "Alice").
-				Set("Region", "us-west-2").
+				Set("name", "Alice").
+				Set("region", "us-west-2").
 				SetTagWithPrefix("awesome", &[]string{"key"}[0], "value"),
 		},
 		{

--- a/pkg/types/properties_test.go
+++ b/pkg/types/properties_test.go
@@ -368,6 +368,7 @@ func TestPropertiesSetFromStruct(t *testing.T) {
 	}
 
 	type testStruct4 struct {
+		Omit bool `property:"-"`
 		Name byte
 	}
 

--- a/pkg/types/properties_test.go
+++ b/pkg/types/properties_test.go
@@ -411,6 +411,24 @@ func TestPropertiesSetFromStruct(t *testing.T) {
 				Set("IQ", 100).
 				SetTag(ptr.String("key1"), "value1"),
 		},
+		{
+			name: "nonempty-struct3-is-set",
+			s: testStruct3{
+				Name: "Alice",
+				Age:  &[]int{42}[0],
+				IQ:   &[]int64{100}[0],
+				On:   true,
+				Tags: []*keyValue{
+					{Key: ptr.String("key1"), Value: ptr.String("value1")},
+				},
+			},
+			want: types.NewProperties().
+				Set("Name", "Alice").
+				Set("Age", 42).
+				Set("IQ", 100).
+				Set("On", true).
+				SetTag(ptr.String("key1"), "value1"),
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/types/properties_test.go
+++ b/pkg/types/properties_test.go
@@ -367,10 +367,15 @@ func TestPropertiesSetFromStruct(t *testing.T) {
 		Tags []*keyValue `property:""`
 	}
 
+	type testStruct4 struct {
+		Name byte
+	}
+
 	cases := []struct {
-		name string
-		s    interface{}
-		want types.Properties
+		name  string
+		s     interface{}
+		want  types.Properties
+		error bool
 	}{
 		{
 			name: "empty",
@@ -429,18 +434,32 @@ func TestPropertiesSetFromStruct(t *testing.T) {
 				Set("On", true).
 				SetTag(ptr.String("key1"), "value1"),
 		},
+		{
+			name: "unsupported-type-panic",
+			s: testStruct4{
+				Name: 'a',
+			},
+			want:  types.NewProperties(),
+			error: true,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			p := types.NewProperties()
 
+			if tc.error {
+				assert.Panics(t, func() {
+					p.SetFromStruct(tc.s)
+				})
+				return
+			}
+
 			p.SetFromStruct(tc.s)
 
 			assert.Equal(t, tc.want, p)
 		})
 	}
-
 }
 
 func getString(value interface{}) string {


### PR DESCRIPTION
## Overview
This is laying the groundwork for allowing the aws-nuke and azure-nuke tool to update their Resource definitions to have exported variables that are then used to build the properties automatically vs having to define them manually.

There are two benefits to this, the first being that we can make the code cleaner and more simple by removing a bunch of for loops for tags, but we can also now programmatically generate documentation by inspecting the resource structs to document what properties are available.

This might make the resource structs get a little more verbose, but in the end, it'll make the use of the tool better.

## Type Support

- string
- int
- int64
- map
- slice
- struct

**Note:** all pointers are dereferenced during evaluation

## Features

- any non-exported field on a struct is ignored and will not be exported as a propery
- `property:"-"` will omit a field from being exported as a property
- `property:"prefix=vpc"` will ensure the value of the field or the tags are prefixed with `vpc`

## Example 

```golang
type ResourceGroup struct {
  client *client
  Name string
  Region *string
  Tags map[string]string
}

types.NewPropertiesFromStruct(&ResourceGroup{
  Name: "example"
  Region: ptr.String("eastus")
  Tags: map[string]string{"key": "value"}
})
```

This automatically will create properties for Name, Region and Tags.

```
[Name: "example", Region: "eastus", tag:key: "value"]
```

## Benchmark

```console
goos: darwin
goarch: amd64
pkg: github.com/ekristen/libnuke/pkg/types
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkNewProperties
BenchmarkNewProperties-16                      	 2815178	       412.1 ns/op
BenchmarkNewPropertiesFromStruct_Simple
BenchmarkNewPropertiesFromStruct_Simple-16     	 1786765	       680.6 ns/op
BenchmarkNewPropertiesFromStruct_Complex
BenchmarkNewPropertiesFromStruct_Complex-16    	  679848	      1702 ns/op
PASS
ok  	github.com/ekristen/libnuke/pkg/types	4.869s
```