### PR TITLE
feat: changes to support gcp-nuke variant

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
+Copyright (c) 2024 Erik Kristensen
 Copyright (c) 2016 reBuy reCommerce GmbH
-Copyright (c) 2023 Erik Kristensen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -15,6 +15,12 @@ func (err ErrUnknownEndpoint) Error() string {
 	return string(err)
 }
 
+type ErrWaitResource string
+
+func (err ErrWaitResource) Error() string {
+	return string(err)
+}
+
 type ErrHoldResource string
 
 func (err ErrHoldResource) Error() string {

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,1 @@
+package errors

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,1 +1,16 @@
-package errors
+package errors_test
+
+import (
+	"errors"
+	error2 "github.com/ekristen/libnuke/pkg/errors"
+	liberrors "github.com/ekristen/libnuke/pkg/errors"
+	"testing"
+)
+
+func TestErrorIs(t *testing.T) {
+	err := error2.ErrSkipRequest("resource is regional")
+	var testErr liberrors.ErrSkipRequest
+	if !errors.As(err, &testErr) {
+		t.Errorf("errors.Is failed")
+	}
+}

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -2,8 +2,9 @@ package errors_test
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	liberrors "github.com/ekristen/libnuke/pkg/errors"
 )

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -2,6 +2,7 @@ package errors_test
 
 import (
 	"errors"
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	liberrors "github.com/ekristen/libnuke/pkg/errors"
@@ -12,5 +13,30 @@ func TestErrorIs(t *testing.T) {
 	var testErr liberrors.ErrSkipRequest
 	if !errors.As(err, &testErr) {
 		t.Errorf("errors.Is failed")
+	}
+}
+
+const testStringValue = "this is just a test"
+
+func TestErrors(t *testing.T) {
+	cases := []struct {
+		err error
+	}{
+		{
+			err: liberrors.ErrSkipRequest(testStringValue),
+		},
+		{liberrors.ErrUnknownEndpoint(testStringValue)},
+		{liberrors.ErrWaitResource(testStringValue)},
+		{liberrors.ErrHoldResource(testStringValue)},
+		{liberrors.ErrUnknownPreset(testStringValue)},
+		{liberrors.ErrDeprecatedResourceType(testStringValue)},
+	}
+
+	for _, c := range cases {
+		if c.err == nil {
+			t.Errorf("error is nil")
+		}
+
+		assert.Equal(t, c.err.Error(), testStringValue)
 	}
 }

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -2,13 +2,13 @@ package errors_test
 
 import (
 	"errors"
-	error2 "github.com/ekristen/libnuke/pkg/errors"
-	liberrors "github.com/ekristen/libnuke/pkg/errors"
 	"testing"
+
+	liberrors "github.com/ekristen/libnuke/pkg/errors"
 )
 
 func TestErrorIs(t *testing.T) {
-	err := error2.ErrSkipRequest("resource is regional")
+	err := liberrors.ErrSkipRequest("resource is regional")
 	var testErr liberrors.ErrSkipRequest
 	if !errors.As(err, &testErr) {
 		t.Errorf("errors.Is failed")

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -34,6 +34,10 @@ var (
 func Sorted(m map[string]string) string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
+		if strings.HasPrefix(k, "_") {
+			continue
+		}
+
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)

--- a/pkg/nuke/nuke.go
+++ b/pkg/nuke/nuke.go
@@ -617,21 +617,23 @@ func (n *Nuke) HandleWait(ctx context.Context, item *queue.Item, cache ListCache
 	}
 
 	for _, r := range left {
-		if item.Equals(r) {
-			rSet, okSet := r.(resource.SettingsGetter)
-			if okSet {
-				rSet.Settings(n.Settings.Get(item.Type))
-			}
-
-			checker, filterOk := r.(resource.Filter)
-			if filterOk {
-				if filterErr := checker.Filter(); filterErr != nil {
-					break
-				}
-			}
-
-			return
+		if !item.Equals(r) {
+			continue
 		}
+
+		rSet, okSet := r.(resource.SettingsGetter)
+		if okSet {
+			rSet.Settings(n.Settings.Get(item.Type))
+		}
+
+		checker, filterOk := r.(resource.Filter)
+		if filterOk {
+			if filterErr := checker.Filter(); filterErr != nil {
+				break
+			}
+		}
+
+		return
 	}
 
 	item.State = queue.ItemStateFinished

--- a/pkg/nuke/nuke.go
+++ b/pkg/nuke/nuke.go
@@ -590,7 +590,7 @@ func (n *Nuke) HandleWait(ctx context.Context, item *queue.Item, cache ListCache
 	if hookOk {
 		if hookErr := waitHook.HandleWait(ctx); hookErr != nil {
 			var waitErr liberrors.ErrWaitResource
-			if errors.Is(hookErr, &waitErr) {
+			if errors.As(hookErr, &waitErr) {
 				item.State = queue.ItemStateWaiting
 				return
 			}

--- a/pkg/nuke/nuke.go
+++ b/pkg/nuke/nuke.go
@@ -585,6 +585,16 @@ func (n *Nuke) HandleWait(ctx context.Context, item *queue.Item, cache ListCache
 	var err error
 
 	ownerID := item.Owner
+
+	waitHook, hookOk := item.Resource.(resource.HandleWaitHook)
+	if hookOk {
+		if err := waitHook.HandleWait(ctx); err != nil {
+			item.State = queue.ItemStateFailed
+			item.Reason = err.Error()
+			return
+		}
+	}
+
 	_, ok := cache[ownerID]
 	if !ok {
 		cache[ownerID] = make(map[string][]resource.Resource)

--- a/pkg/nuke/nuke_filter_test.go
+++ b/pkg/nuke/nuke_filter_test.go
@@ -233,6 +233,7 @@ func Test_Nuke_Filters_Extra(t *testing.T) {
 func Test_Nuke_Filters_Filtered(t *testing.T) {
 	cases := []struct {
 		name      string
+		error     bool
 		resources []resource.Resource
 		filters   filter.Filters
 	}{
@@ -281,6 +282,26 @@ func Test_Nuke_Filters_Filtered(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "invalid",
+			error: true,
+			resources: []resource.Resource{
+				&TestResourceFilter{
+					Props: types.Properties{
+						"tag:aws:cloudformation:stack-name": "StackSet-AWSControlTowerBP-VPC-ACCOUNT-FACTORY-V1-c0bdd9c9-c338-4831-9c47-62443622c081",
+					},
+				},
+			},
+			filters: filter.Filters{
+				TestResourceType2: []filter.Filter{
+					{
+						Type:     "invalid-filter",
+						Property: "tag:aws:cloudformation:stack-name",
+						Value:    "StackSet-AWSControlTowerBP-VPC-ACCOUNT-FACTORY-V1-c0bdd9c9-c338-4831-9c47-62443622c081",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -296,6 +317,11 @@ func Test_Nuke_Filters_Filtered(t *testing.T) {
 				}
 
 				err := n.Filter(i)
+				if tc.error == true {
+					assert.Error(t, err)
+					continue
+				}
+
 				assert.NoError(t, err)
 				assert.Equal(t, i.Reason, "filtered by config")
 			}

--- a/pkg/nuke/nuke_run_test.go
+++ b/pkg/nuke/nuke_run_test.go
@@ -344,3 +344,25 @@ func TestNuke_RunWithHandleWaitFail(t *testing.T) {
 	assert.Equal(t, 0, n.Queue.Count(queue.ItemStateFinished))
 	assert.Equal(t, 1, n.Queue.Count(queue.ItemStateFailed))
 }
+
+func TestNuke_RunNoResources(t *testing.T) {
+	n := New(&Parameters{
+		Force:              true,
+		ForceSleep:         3,
+		Quiet:              true,
+		NoDryRun:           true,
+		WaitOnDependencies: true,
+	}, nil, nil)
+	n.SetLogger(logrus.WithField("test", true))
+
+	registry.ClearRegistry()
+
+	newScanner := scanner.New("Owner", []string{}, nil)
+	scannerErr := n.RegisterScanner(testScope, newScanner)
+	assert.NoError(t, scannerErr)
+
+	runErr := n.Run(context.TODO())
+	assert.NoError(t, runErr)
+
+	assert.Equal(t, 0, n.Queue.Count(queue.ItemStateNew))
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -88,6 +88,11 @@ type Lister interface {
 	List(ctx context.Context, opts interface{}) ([]resource.Resource, error)
 }
 
+// ListerWithClose is an interface that represents a lister that can be closed. Use Case: GCP clients need to be closed.
+type ListerWithClose interface {
+	Close()
+}
+
 // RegisterOption is a function that can be used to manipulate the lister for a given resource type at
 // registration time
 type RegisterOption func(name string, lister Lister)

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -32,3 +32,8 @@ type SettingsGetter interface {
 	Resource
 	Settings(setting *settings.Setting)
 }
+
+type HandleWaitHook interface {
+	Resource
+	HandleWait(context.Context) error
+}

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -74,3 +74,9 @@ func TestSettings_SetSetting(t *testing.T) {
 	assert.Nil(t, s.Get("DisableStopProtection"))
 	assert.Nil(t, s.Get("ForceDeleteLightsailAddOns"))
 }
+
+func TestSettings_GetNil(t *testing.T) {
+	var s *Settings = nil
+	set := s.Get("key")
+	assert.Nil(t, set)
+}

--- a/pkg/types/properties.go
+++ b/pkg/types/properties.go
@@ -21,8 +21,9 @@ func NewPropertiesFromStruct(data interface{}) Properties {
 	return NewProperties().SetFromStruct(data)
 }
 
-func (p Properties) SetTagPrefix(prefix string) {
+func (p Properties) SetTagPrefix(prefix string) Properties {
 	p["_tagPrefix"] = prefix
+	return p
 }
 
 // String returns a string representation of the Properties map.

--- a/pkg/types/properties_test.go
+++ b/pkg/types/properties_test.go
@@ -383,6 +383,11 @@ func TestPropertiesSetFromStruct(t *testing.T) {
 		unexported string
 	}
 
+	type testStruct7 struct {
+		Name   string
+		Labels map[string]string
+	}
+
 	cases := []struct {
 		name  string
 		s     interface{}
@@ -479,6 +484,14 @@ func TestPropertiesSetFromStruct(t *testing.T) {
 				unexported: "hidden",
 			},
 			want: types.NewProperties().Set("Name", "Alice").SetTag(ptr.String("key"), "value"),
+		},
+		{
+			name: "labels-map-string-string",
+			s: testStruct7{
+				Name:   "Bob",
+				Labels: map[string]string{"key": "value"},
+			},
+			want: types.NewProperties().Set("Name", "Bob").SetTag(ptr.String("key"), "value"),
 		},
 	}
 

--- a/pkg/types/properties_test.go
+++ b/pkg/types/properties_test.go
@@ -385,7 +385,7 @@ func TestPropertiesSetFromStruct(t *testing.T) {
 
 	type testStruct7 struct {
 		Name   string
-		Labels map[string]string
+		Labels map[string]string `property:"tagPrefix=label"`
 	}
 
 	cases := []struct {
@@ -491,7 +491,7 @@ func TestPropertiesSetFromStruct(t *testing.T) {
 				Name:   "Bob",
 				Labels: map[string]string{"key": "value"},
 			},
-			want: types.NewProperties().Set("Name", "Bob").SetTag(ptr.String("key"), "value"),
+			want: types.NewProperties().SetTagPrefix("label").Set("Name", "Bob").SetTag(ptr.String("key"), "value"),
 		},
 	}
 


### PR DESCRIPTION
This implements a series of changes that allows for the gcp-nuke variant to be completed and follow the same patterns as aws-nuke and azure-nuke before it. Due to how the google golang sdk is written a few additional features needed to be added to allow for proper teardown of clients, renaming of tags to labels, and for filtering to be able to access settings.