### PR TITLE
feat: allow resource to hook the parent item for modification

### DIFF
--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -33,7 +33,17 @@ type SettingsGetter interface {
 	Settings(setting *settings.Setting)
 }
 
+// HandleWaitHook is an interface that allows a resource to handle waiting for a resource to be deleted.
+// This is useful for resources that may take a while to delete, typically where the delete operation happens
+// asynchronously from the initial delete command. This allows libnuke to not block during the delete operation.
 type HandleWaitHook interface {
 	Resource
 	HandleWait(context.Context) error
+}
+
+// QueueItemHook is an interface that allows a resource to modify the queue item to which it belongs to.
+// For advanced use only, please use with caution!
+type QueueItemHook interface {
+	Resource
+	ModifyItem(interface{})
 }

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -45,5 +45,5 @@ type HandleWaitHook interface {
 // For advanced use only, please use with caution!
 type QueueItemHook interface {
 	Resource
-	ModifyItem(interface{})
+	BeforeQueueAdd(interface{})
 }

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -45,5 +45,5 @@ type HandleWaitHook interface {
 // For advanced use only, please use with caution!
 type QueueItemHook interface {
 	Resource
-	BeforeQueueAdd(interface{})
+	BeforeEnqueue(interface{})
 }

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -150,6 +150,12 @@ func (s *Scanner) list(ctx context.Context, owner, resourceType string, opts int
 			Owner:    owner,
 			Opts:     opts,
 		}
+
+		itemHook, ok := r.(resource.QueueItemHook)
+		if ok {
+			itemHook.ModifyItem(i)
+		}
+
 		s.Items <- i
 	}
 }

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -153,7 +153,7 @@ func (s *Scanner) list(ctx context.Context, owner, resourceType string, opts int
 
 		itemHook, ok := r.(resource.QueueItemHook)
 		if ok {
-			itemHook.ModifyItem(i)
+			itemHook.BeforeEnqueue(i)
 		}
 
 		s.Items <- i

--- a/pkg/scanner/scanner_test.go
+++ b/pkg/scanner/scanner_test.go
@@ -41,6 +41,7 @@ func Test_NewScannerWithMorphOpts(t *testing.T) {
 	for item := range scanner.Items {
 		assert.Equal(t, "testing", item.Opts.(TestOpts).SessionOne)
 		assert.Equal(t, "testing-testResourceType", item.Opts.(TestOpts).SessionTwo)
+		assert.Equal(t, "OwnerModded", item.Owner)
 	}
 }
 

--- a/pkg/scanner/testsuite_test.go
+++ b/pkg/scanner/testsuite_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/ekristen/libnuke/pkg/queue"
 	"io"
 	"testing"
 	"time"
@@ -57,6 +58,11 @@ func (r *TestResource) Remove(_ context.Context) error {
 
 func (r *TestResource) Settings(setting *settings.Setting) {
 
+}
+
+func (r *TestResource) ModifyItem(item interface{}) {
+	i := item.(*queue.Item)
+	i.Owner = "OwnerModded"
 }
 
 type TestResource2 struct {

--- a/pkg/scanner/testsuite_test.go
+++ b/pkg/scanner/testsuite_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/ekristen/libnuke/pkg/queue"
 	"io"
 	"testing"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ekristen/libnuke/pkg/errors"
+	"github.com/ekristen/libnuke/pkg/queue"
 	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
 	"github.com/ekristen/libnuke/pkg/settings"

--- a/pkg/scanner/testsuite_test.go
+++ b/pkg/scanner/testsuite_test.go
@@ -60,7 +60,7 @@ func (r *TestResource) Settings(setting *settings.Setting) {
 
 }
 
-func (r *TestResource) ModifyItem(item interface{}) {
+func (r *TestResource) BeforeEnqueue(item interface{}) {
 	i := item.(*queue.Item)
 	i.Owner = "OwnerModded"
 }

--- a/pkg/types/properties.go
+++ b/pkg/types/properties.go
@@ -220,7 +220,7 @@ func (p Properties) SetFromStruct(data interface{}) Properties { //nolint:funlen
 
 		if inline {
 			p.SetFromStruct(value.Interface())
-			//continue
+			continue
 		}
 
 		if tagPrefix != "" {

--- a/pkg/types/properties.go
+++ b/pkg/types/properties.go
@@ -193,9 +193,14 @@ func (p Properties) SetFromStruct(data interface{}) Properties { //nolint:funlen
 		name := field.Name
 		prefix := ""
 		tagPrefix := ""
+		inline := false
 
 		if options[0] == "-" {
 			continue
+		}
+
+		if len(options) == 2 && options[1] == "inline" {
+			inline = true
 		}
 
 		for _, option := range options {
@@ -213,6 +218,11 @@ func (p Properties) SetFromStruct(data interface{}) Properties { //nolint:funlen
 			}
 		}
 
+		if inline {
+			p.SetFromStruct(value.Interface())
+			//continue
+		}
+
 		if tagPrefix != "" {
 			p.SetTagPrefix(tagPrefix)
 		}
@@ -222,6 +232,8 @@ func (p Properties) SetFromStruct(data interface{}) Properties { //nolint:funlen
 		}
 
 		switch value.Kind() {
+		case reflect.Struct:
+			// do nothing
 		case reflect.Map:
 			for _, key := range value.MapKeys() {
 				val := value.MapIndex(key)

--- a/pkg/types/properties_test.go
+++ b/pkg/types/properties_test.go
@@ -388,6 +388,22 @@ func TestPropertiesSetFromStruct(t *testing.T) {
 		Labels map[string]string `property:"tagPrefix=label"`
 	}
 
+	type TestStruct8 struct {
+		Name string
+	}
+
+	type testStruct9 struct {
+		*TestStruct8 `property:",inline"`
+
+		Region string
+	}
+
+	type testStruct10 struct {
+		*TestStruct8
+
+		Region string
+	}
+
 	cases := []struct {
 		name  string
 		s     interface{}
@@ -492,6 +508,22 @@ func TestPropertiesSetFromStruct(t *testing.T) {
 				Labels: map[string]string{"key": "value"},
 			},
 			want: types.NewProperties().SetTagPrefix("label").Set("Name", "Bob").SetTag(ptr.String("key"), "value"),
+		},
+		{
+			name: "struct-with-inline",
+			s: testStruct9{
+				TestStruct8: &TestStruct8{Name: "Alice"},
+				Region:      "us-west-2",
+			},
+			want: types.NewProperties().Set("Name", "Alice").Set("Region", "us-west-2"),
+		},
+		{
+			name: "struct-without-inline",
+			s: testStruct10{
+				TestStruct8: &TestStruct8{Name: "Alice"},
+				Region:      "us-west-2",
+			},
+			want: types.NewProperties().Set("Region", "us-west-2"),
 		},
 	}
 


### PR DESCRIPTION
## Overview
This is a set of modifications to allow better alignment in the [azure-nuke](https://github.com/ekristen/azure-nuke) variant. Due to how azure APIs work, you have to globally query, but we still want to maintain the regional aspect. Also with Azure there is a lot of commonality in resources, so these changes allow for changing of the regional information at scan time, and allows for properties to be exposed from composition.

## Features
- `BeforeEnqueue` hook that is optional on a resource, this allows the resource to modify the item before being put on the queue.
    > The primary use case for this is that with Azure we cannot scan by region, we can to scan by tenant, subscription and resource group, therefore, this allows us to swap out the scanning owner to the actual region once it's discovered. The side affect is that resources may appear out of order when attributed to specific regions.
- `Properties from Struct Composition` - allows inlining properities for a struct composition. 