### PR TITLE
fix: account-blocklist deprecation message

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -147,7 +147,7 @@ func (c *Config) ResolveBlocklist() []string {
 	if len(c.AccountBlocklist) > 0 {
 		blocklist = append(blocklist, c.AccountBlocklist...)
 		c.AccountBlocklist = nil
-		c.Log.Warn("deprecated configuration key 'account-blacklist' - please use 'blocklist' instead")
+		c.Log.Warn("deprecated configuration key 'account-blocklist' - please use 'blocklist' instead")
 	}
 
 	if len(c.AccountBlacklist) > 0 {


### PR DESCRIPTION
It logged `account-blocklist` as `account-blacklist` before.

For a config with `account-blocklist`

```yaml
account-blocklist:
- "999999999999"
```

Before:

```console
$ ./aws-nuke run -c nuke-cfg.yaml
WARN[0000] deprecated configuration key 'account-blacklist' - please use 'blocklist' instead  component=config
> aws-nuke - 3.0.0-dev - dirty
Do you really want to nuke the account with the ID XXXXX and the alias 'xxxxx'?
Do you want to continue? Enter account alias to continue.
```

After:

```console
$ ./aws-nuke run -c nuke-cfg.yaml
WARN[0000] deprecated configuration key 'account-blocklist' - please use 'blocklist' instead  component=config
> aws-nuke - 3.0.0-dev - dirty
Do you really want to nuke the account with the ID XXXXX and the alias 'xxxxx'?
Do you want to continue? Enter account alias to continue.
```