### PR TITLE
fix(queue): match props first then stringer

### DIFF
--- a/pkg/queue/item.go
+++ b/pkg/queue/item.go
@@ -84,15 +84,6 @@ func (i *Item) Equals(o resource.Resource) bool {
 		return false
 	}
 
-	iStringer, iOK := i.Resource.(resource.LegacyStringer)
-	oStringer, oOK := o.(resource.LegacyStringer)
-	if iOK != oOK {
-		return false
-	}
-	if iOK && oOK {
-		return iStringer.String() == oStringer.String()
-	}
-
 	iGetter, iOK := i.Resource.(resource.PropertyGetter)
 	oGetter, oOK := o.(resource.PropertyGetter)
 	if iOK != oOK {
@@ -100,6 +91,15 @@ func (i *Item) Equals(o resource.Resource) bool {
 	}
 	if iOK && oOK {
 		return iGetter.Properties().Equals(oGetter.Properties())
+	}
+
+	iStringer, iOK := i.Resource.(resource.LegacyStringer)
+	oStringer, oOK := o.(resource.LegacyStringer)
+	if iOK != oOK {
+		return false
+	}
+	if iOK && oOK {
+		return iStringer.String() == oStringer.String()
 	}
 
 	return false

--- a/pkg/queue/item_test.go
+++ b/pkg/queue/item_test.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -235,4 +236,39 @@ func Test_ItemEqualNothing(t *testing.T) {
 	}
 
 	assert.False(t, i.Equals(i.Resource))
+}
+
+// ------------------------------------------------------------------------
+
+type TestItemResourceRevenant struct {
+	Props types.Properties
+}
+
+func (r *TestItemResourceRevenant) Remove(_ context.Context) error {
+	return nil
+}
+func (r *TestItemResourceRevenant) Properties() types.Properties {
+	return r.Props
+}
+
+func Test_ItemRevenant(t *testing.T) {
+	i := &Item{
+		Resource: &TestItemResourceRevenant{
+			Props: types.NewProperties().Set("CreatedAt", time.Now().UTC()),
+		},
+		State:  ItemStateNew,
+		Reason: "brand new",
+		Type:   "TestResource",
+	}
+
+	j := &Item{
+		Resource: &TestItemResourceRevenant{
+			Props: types.NewProperties().Set("CreatedAt", time.Now().UTC().Add(4*time.Minute)),
+		},
+		State:  ItemStateNew,
+		Reason: "brand new",
+		Type:   "TestResource",
+	}
+
+	assert.False(t, j.Equals(i.Resource))
 }


### PR DESCRIPTION
Switching to match on all properties is better than doing just stringer match. 

For example with Cloud Watch Log Groups, if the name is `eks-cluster` and it gets removed, but something is still writing to it, it will get created and the name with match, so libnuke will keep the resource in waiting to be removed forever state. However if we move to matching on all props, then the CreateAt date shifts between first detecting and the second, and will consider the original resource deleted and the new one a new resource.

Until DAG deletion is supported, unfortunately this means that we might have to run the tool twice.