### PR TITLE
feat: filter groups

### DIFF
--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -3,7 +3,6 @@ package filter
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"regexp"
 	"slices"
 	"strconv"
@@ -11,6 +10,7 @@ import (
 	"time"
 
 	"github.com/mb0/glob"
+	"github.com/sirupsen/logrus"
 )
 
 type OpType string
@@ -307,11 +307,11 @@ func (f *Filter) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if m["invert"] == nil {
 		f.Invert = false
 	} else {
-		switch m["invert"].(type) {
+		switch val := m["invert"].(type) {
 		case bool:
-			f.Invert = m["invert"].(bool)
+			f.Invert = val
 		case string:
-			invert, err := strconv.ParseBool(m["invert"].(string))
+			invert, err := strconv.ParseBool(val)
 			if err != nil {
 				return err
 			}

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -111,7 +111,7 @@ func (f Filters) Merge(f2 Filters) {
 func (f Filters) Match(resourceType string, p Property) (bool, error) {
 	resourceFilters := f.GetByGroup(resourceType)
 	if resourceFilters == nil {
-		return true, nil
+		return false, nil
 	}
 
 	groupCount := make(map[string]int)
@@ -125,16 +125,16 @@ func (f Filters) Match(resourceType string, p Property) (bool, error) {
 			prop, err := p.GetProperty(filter.Property)
 			if err != nil {
 				logrus.WithError(err).Warn("error getting property")
-				continue
+				return false, err
 			}
 
 			match, err := filter.Match(prop)
 			if err != nil {
 				logrus.WithError(err).Warn("error matching filter")
-				continue
+				return false, err
 			}
 
-			fmt.Println(match, filter.Invert)
+			logrus.Trace(match, filter.Invert)
 
 			if filter.Invert {
 				match = !match
@@ -145,9 +145,9 @@ func (f Filters) Match(resourceType string, p Property) (bool, error) {
 			}
 		}
 
-		fmt.Println("groupCount", groupCount)
-		fmt.Println("totalCount", totalCount)
-		fmt.Println("matchCount", matchCount)
+		logrus.Trace("groupCount", groupCount)
+		logrus.Trace("totalCount", totalCount)
+		logrus.Trace("matchCount", matchCount)
 
 		if totalCount[group] == matchCount[group] {
 			groupCount[group]++

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -60,6 +60,8 @@ func (f Filters) Get(resourceType string) []Filter {
 	return filters
 }
 
+// GetByGroup returns the filters grouped by the group name for a specific resource type. If there are no filters it
+// returns nil
 func (f Filters) GetByGroup(resourceType string) map[string][]Filter {
 	filters := make(Filters)
 
@@ -108,6 +110,8 @@ func (f Filters) Merge(f2 Filters) {
 	f.Append(f2)
 }
 
+// Match checks if the filters match the given property which is actually a queue item that meats the
+// property interface requirements
 func (f Filters) Match(resourceType string, p Property) (bool, error) {
 	resourceFilters := f.GetByGroup(resourceType)
 	if resourceFilters == nil {
@@ -162,27 +166,25 @@ func (f Filters) Match(resourceType string, p Property) (bool, error) {
 	return false, nil
 }
 
-// ----------------
-
 // Filter is a filter to apply to a resource
 type Filter struct {
 	// Group is the name of the group of filters, all filters in a group are ANDed together
-	Group string
+	Group string `yaml:"group" json:"group"`
 
 	// Type is the type of filter to apply
-	Type Type
+	Type Type `yaml:"type" json:"type"`
 
 	// Property is the name of the property to filter on
-	Property string
+	Property string `yaml:"property" json:"property"`
 
 	// Value is the value to filter on
-	Value string
+	Value string `yaml:"value" json:"value"`
 
 	// Values allows for multiple values to be specified for a filter
 	Values []string `yaml:"values" json:"values"`
 
 	// Invert is a flag to invert the filter
-	Invert bool
+	Invert bool `yaml:"invert" json:"invert"`
 }
 
 // GetGroup returns the group name of the filter, if it is empty it returns "default"
@@ -254,6 +256,7 @@ func (f *Filter) Match(o string) (bool, error) {
 	}
 }
 
+// UnmarshalYAML unmarshals a filter from YAML data
 func (f *Filter) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var value string
 

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -1,7 +1,6 @@
 package filter_test
 
 import (
-	"github.com/ekristen/libnuke/pkg/types"
 	"os"
 	"reflect"
 	"strconv"
@@ -13,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ekristen/libnuke/pkg/filter"
+	"github.com/ekristen/libnuke/pkg/types"
 )
 
 func TestFilter_Nil(t *testing.T) {

--- a/pkg/filter/testdata/groups.yaml
+++ b/pkg/filter/testdata/groups.yaml
@@ -1,0 +1,16 @@
+filters:
+  Resource1:
+    - property: prop1
+      type: exact
+      value: value1
+    - property: prop2
+      type: exact
+      value: value2
+    - property: prop3
+      type: exact
+      value: value3
+      group: something-else
+  Resource2:
+    - property: prop2
+      type: exact
+      value: value2

--- a/pkg/filter/testsuite_test.go
+++ b/pkg/filter/testsuite_test.go
@@ -2,6 +2,7 @@ package filter_test
 
 import (
 	"fmt"
+
 	"github.com/ekristen/libnuke/pkg/types"
 )
 

--- a/pkg/filter/testsuite_test.go
+++ b/pkg/filter/testsuite_test.go
@@ -1,0 +1,7 @@
+package filter_test
+
+type TestResource struct{}
+
+func (t *TestResource) GetProperty(key string) (string, error) {
+	return "testing", nil
+}

--- a/pkg/filter/testsuite_test.go
+++ b/pkg/filter/testsuite_test.go
@@ -1,7 +1,24 @@
 package filter_test
 
-type TestResource struct{}
+import (
+	"fmt"
+	"github.com/ekristen/libnuke/pkg/types"
+)
+
+type TestResource struct {
+	Props types.Properties
+}
 
 func (t *TestResource) GetProperty(key string) (string, error) {
+	if key == "no_stringer" {
+		return "", fmt.Errorf("does not support legacy IDs")
+	} else if key == "no_properties" {
+		return "", fmt.Errorf("does not support custom properties")
+	}
+
 	return "testing", nil
+}
+
+func (t *TestResource) Properties() types.Properties {
+	return t.Props
 }

--- a/pkg/nuke/nuke.go
+++ b/pkg/nuke/nuke.go
@@ -40,6 +40,12 @@ type Parameters struct {
 	// processed
 	WaitOnDependencies bool
 
+	// UseFilterGroups controls whether the filter groups are used or not. If set to true, then the filters will be
+	// processed by groups, where each group is a list of filters that are processed together. A single filter in a
+	// group must match for the group to match. If set to false, then the filters will be processed individually and
+	// a single filter must match for the resource to be filtered.
+	UseFilterGroups bool
+
 	// Includes is a list of resource types that are to be included during the nuke process. If a resource type is
 	// listed in both the Includes and Excludes fields then the Excludes field will take precedence.
 	Includes []string
@@ -448,6 +454,18 @@ func (n *Nuke) Filter(item *queue.Item) error {
 		}
 	}
 
+	if n.Parameters.UseFilterGroups {
+		return n.filterWithGroups(item)
+	}
+
+	return n.filterWithoutGroups(item)
+}
+
+func (n *Nuke) filterWithGroups(item *queue.Item) error {
+	log := n.log.
+		WithField("handler", "Filter").
+		WithField("type", item.Type)
+
 	matched, err := n.Filters.Match(item.Type, item)
 	if err != nil {
 		return err
@@ -457,50 +475,55 @@ func (n *Nuke) Filter(item *queue.Item) error {
 		log.Trace("resource was filtered by config")
 		item.State = queue.ItemStateFiltered
 		item.Reason = "filtered by config"
+	}
+
+	return nil
+}
+
+func (n *Nuke) filterWithoutGroups(item *queue.Item) error {
+	log := n.log.
+		WithField("handler", "Filter").
+		WithField("type", item.Type)
+
+	itemFilters := n.Filters.Get(item.Type)
+	if itemFilters == nil {
+		log.Tracef("no filters found for type: %s", item.Type)
 		return nil
 	}
 
-	/*
-		itemFilters := n.Filters.Get(item.Type)
-		if itemFilters == nil {
-			log.Tracef("no filters found for type: %s", item.Type)
+	for _, f := range itemFilters {
+		log.
+			WithField("prop", f.Property).
+			WithField("type", f.Type).
+			WithField("value", f.Value).
+			Trace("filter details")
+
+		prop, err := item.GetProperty(f.Property)
+		if err != nil {
+			return err
+		}
+
+		log.Tracef("property: %s", prop)
+
+		match, err := f.Match(prop)
+		if err != nil {
+			return err
+		}
+
+		log.Tracef("match: %t", match)
+
+		if f.Invert {
+			log.WithField("orig", match).WithField("new", !match).Trace("filter inverted")
+			match = !match
+		}
+
+		if match {
+			log.Trace("filter matched")
+			item.State = queue.ItemStateFiltered
+			item.Reason = "filtered by config"
 			return nil
 		}
-
-		for _, f := range itemFilters {
-			log.
-				WithField("prop", f.Property).
-				WithField("type", f.Type).
-				WithField("value", f.Value).
-				Trace("filter details")
-
-			prop, err := item.GetProperty(f.Property)
-			if err != nil {
-				return err
-			}
-
-			log.Tracef("property: %s", prop)
-
-			match, err := f.Match(prop)
-			if err != nil {
-				return err
-			}
-
-			log.Tracef("match: %t", match)
-
-			if f.Invert {
-				log.WithField("orig", match).WithField("new", !match).Trace("filter inverted")
-				match = !match
-			}
-
-			if match {
-				log.Trace("filter matched")
-				item.State = queue.ItemStateFiltered
-				item.Reason = "filtered by config"
-				return nil
-			}
-		}
-	*/
+	}
 
 	return nil
 }

--- a/pkg/nuke/nuke_filter_test.go
+++ b/pkg/nuke/nuke_filter_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"io"
-	"strings"
 	"testing"
 	"time"
 
@@ -146,20 +145,6 @@ func Test_Nuke_Filters_NoMatch(t *testing.T) {
 }
 
 func Test_Nuke_Filters_ErrorCustomProps(t *testing.T) {
-	logrus.AddHook(&TestGlobalHook{
-		t: t,
-		tf: func(t *testing.T, e *logrus.Entry) {
-			if strings.HasSuffix(e.Caller.File, "pkg/nuke/nuke.go") {
-				return
-			}
-
-			if e.Caller.Line == 467 {
-				assert.Equal(t, "*nuke.TestResource does not support custom properties", e.Message)
-			}
-		},
-	})
-	defer logrus.StandardLogger().ReplaceHooks(make(logrus.LevelHooks))
-
 	registry.ClearRegistry()
 	registry.Register(TestResourceRegistration)
 
@@ -186,7 +171,8 @@ func Test_Nuke_Filters_ErrorCustomProps(t *testing.T) {
 	assert.NoError(t, sErr)
 
 	err := n.Scan(context.TODO())
-	assert.NoError(t, err)
+	assert.Error(t, err)
+	assert.Equal(t, "*nuke.TestResource does not support custom properties", err.Error())
 }
 
 type TestResourceFilter struct {

--- a/pkg/nuke/nuke_filter_test.go
+++ b/pkg/nuke/nuke_filter_test.go
@@ -77,6 +77,86 @@ func Test_NukeFiltersMatch(t *testing.T) {
 	assert.Equal(t, 1, n.Queue.Count(queue.ItemStateFiltered))
 }
 
+func Test_NukeFiltersMatchGroups_Match(t *testing.T) {
+	registry.ClearRegistry()
+	registry.Register(TestResourceRegistration2)
+
+	filters := filter.Filters{
+		TestResourceType2: []filter.Filter{
+			{
+				Type:     filter.Exact,
+				Property: "test",
+				Value:    "testing",
+				Group:    "group1",
+			},
+			{
+				Type:     filter.Exact,
+				Property: "test2",
+				Value:    "testing",
+				Group:    "group2",
+			},
+		},
+	}
+
+	n := New(testParametersGroups, filters, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
+
+	opts := TestOpts{
+		SessionOne:     "testing",
+		SecondResource: true,
+	}
+	newScanner := scanner.New("Owner", []string{TestResourceType2}, opts)
+
+	sErr := n.RegisterScanner(testScope, newScanner)
+	assert.NoError(t, sErr)
+
+	err := n.Scan(context.TODO())
+	assert.NoError(t, err)
+	assert.Equal(t, 1, n.Queue.Total())
+	assert.Equal(t, 1, n.Queue.Count(queue.ItemStateFiltered))
+}
+
+func Test_NukeFiltersMatchGroups_NoMatch(t *testing.T) {
+	registry.ClearRegistry()
+	registry.Register(TestResourceRegistration2)
+
+	filters := filter.Filters{
+		TestResourceType2: []filter.Filter{
+			{
+				Type:     filter.Exact,
+				Property: "test",
+				Value:    "testing",
+				Group:    "group1",
+			},
+			{
+				Type:     filter.Exact,
+				Property: "test2",
+				Value:    "testing!!!",
+				Group:    "group2",
+			},
+		},
+	}
+
+	n := New(testParametersGroups, filters, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
+
+	opts := TestOpts{
+		SessionOne:     "testing",
+		SecondResource: true,
+	}
+	newScanner := scanner.New("Owner", []string{TestResourceType2}, opts)
+
+	sErr := n.RegisterScanner(testScope, newScanner)
+	assert.NoError(t, sErr)
+
+	err := n.Scan(context.TODO())
+	assert.NoError(t, err)
+	assert.Equal(t, 1, n.Queue.Total())
+	assert.Equal(t, 1, n.Queue.Count(queue.ItemStateFiltered))
+}
+
 func Test_NukeFiltersMatchInverted(t *testing.T) {
 	registry.ClearRegistry()
 	registry.Register(TestResourceRegistration2)

--- a/pkg/nuke/nuke_filter_test.go
+++ b/pkg/nuke/nuke_filter_test.go
@@ -88,7 +88,7 @@ func Test_NukeFiltersMatchInverted(t *testing.T) {
 				Type:     filter.Exact,
 				Property: "test",
 				Value:    "testing",
-				Invert:   "true",
+				Invert:   true,
 			},
 		},
 	}

--- a/pkg/nuke/nuke_test.go
+++ b/pkg/nuke/nuke_test.go
@@ -35,6 +35,14 @@ var testParametersRemove = &Parameters{
 	NoDryRun:   true,
 }
 
+var testParametersGroups = &Parameters{
+	Force:           true,
+	ForceSleep:      3,
+	Quiet:           false,
+	NoDryRun:        false,
+	UseFilterGroups: true,
+}
+
 const testScope registry.Scope = "test"
 
 func Test_Nuke_Version(t *testing.T) {

--- a/pkg/nuke/testsuite_test.go
+++ b/pkg/nuke/testsuite_test.go
@@ -152,5 +152,6 @@ func (r *TestResource2) Remove(_ context.Context) error {
 func (r *TestResource2) Properties() types.Properties {
 	props := types.NewProperties()
 	props.Set("test", "testing")
+	props.Set("test2", "testing")
 	return props
 }

--- a/pkg/queue/item.go
+++ b/pkg/queue/item.go
@@ -86,18 +86,12 @@ func (i *Item) Equals(o resource.Resource) bool {
 
 	iStringer, iOK := i.Resource.(resource.LegacyStringer)
 	oStringer, oOK := o.(resource.LegacyStringer)
-	if iOK != oOK {
-		return false
-	}
 	if iOK && oOK {
 		return iStringer.String() == oStringer.String()
 	}
 
 	iGetter, iOK := i.Resource.(resource.PropertyGetter)
 	oGetter, oOK := o.(resource.PropertyGetter)
-	if iOK != oOK {
-		return false
-	}
 	if iOK && oOK {
 		return iGetter.Properties().Equals(oGetter.Properties())
 	}


### PR DESCRIPTION
This adds the feature filter groups.

Filter groups adds a new element to a filter called group. By default it's set to 'default'.

Filter groups allow you to AND filters together.

Filters within a group are OR'd together.

Filter groups are AND'd together.