### PR TITLE
fix: do not throw an error, revert to log and continue

### DIFF
--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -129,8 +129,11 @@ func (f Filters) Match(resourceType string, p Property) (bool, error) {
 		for _, filter := range groupFilters {
 			prop, err := p.GetProperty(filter.Property)
 			if err != nil {
+				// Note: this continues because we want it to continue if a property is not found for the time
+				// being. This can also return an error we want as a warning if a resource does not support
+				// custom properties. This can be triggered by __global__ filters that are applied to all resources.
 				logrus.WithError(err).Warn("error getting property")
-				return false, err
+				continue
 			}
 
 			match, err := filter.Match(prop)

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -277,7 +277,8 @@ func TestFilter_MatchGroup(t *testing.T) {
 				},
 			},
 			filtered: false,
-			error:    true,
+			// TODO: add in log handler checks for error as this throws a warning
+			error: false,
 		},
 		{
 			name:     "single-group-invalid-type",

--- a/pkg/nuke/nuke.go
+++ b/pkg/nuke/nuke.go
@@ -500,7 +500,11 @@ func (n *Nuke) filterWithoutGroups(item *queue.Item) error {
 
 		prop, err := item.GetProperty(f.Property)
 		if err != nil {
-			return err
+			// Note: this needs to remain a warning. There needs to be additional logic and handling for
+			// properties that do not exist if we wish to do something about it. Additionally, the __global__ is
+			// a special case that is used to filter all resources.
+			log.WithError(err).Warnf("unable to get property: %s", f.Property)
+			continue
 		}
 
 		log.Tracef("property: %s", prop)

--- a/pkg/nuke/nuke_filter_test.go
+++ b/pkg/nuke/nuke_filter_test.go
@@ -290,8 +290,11 @@ func Test_Nuke_Filters_ErrorCustomProps(t *testing.T) {
 	assert.NoError(t, sErr)
 
 	err := n.Scan(context.TODO())
-	assert.Error(t, err)
-	assert.Equal(t, "*nuke.TestResource does not support custom properties", err.Error())
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, n.Queue.Total())
+	assert.Equal(t, 1, n.Queue.Count(queue.ItemStateNew))
+	assert.Equal(t, 0, n.Queue.Count(queue.ItemStateFiltered))
 }
 
 type TestResourceFilter struct {


### PR DESCRIPTION
This was a bug that was inadvertently added during support for the experimental feature groups feature. For now this is being reverted back to warn and continue as it should have been.