### PR TITLE
fix(filter): filter group logic

### DIFF
--- a/pkg/filter/testsuite_test.go
+++ b/pkg/filter/testsuite_test.go
@@ -17,7 +17,7 @@ func (t *TestResource) GetProperty(key string) (string, error) {
 		return "", fmt.Errorf("does not support custom properties")
 	}
 
-	return "testing", nil
+	return t.Props[key], nil
 }
 
 func (t *TestResource) Properties() types.Properties {

--- a/pkg/nuke/nuke.go
+++ b/pkg/nuke/nuke.go
@@ -485,7 +485,7 @@ func (n *Nuke) filterWithGroups(item *queue.Item) error {
 		WithField("handler", "Filter").
 		WithField("type", item.Type)
 
-	matched, err := n.Filters.Match(item.Type, item)
+	matched, err := n.Filters.Match(item.Type, item, log)
 	if err != nil {
 		return err
 	}

--- a/pkg/nuke/nuke_filter_test.go
+++ b/pkg/nuke/nuke_filter_test.go
@@ -154,7 +154,7 @@ func Test_NukeFiltersMatchGroups_NoMatch(t *testing.T) {
 	err := n.Scan(context.TODO())
 	assert.NoError(t, err)
 	assert.Equal(t, 1, n.Queue.Total())
-	assert.Equal(t, 1, n.Queue.Count(queue.ItemStateFiltered))
+	assert.Equal(t, 0, n.Queue.Count(queue.ItemStateFiltered))
 }
 
 func Test_NukeFiltersMatchGroups_NoMatch_WithError(t *testing.T) {


### PR DESCRIPTION
This fixes a few issues with filter groups:
* The `group` attribute was being ignored in the YAML config. We now set it in `UnmarshalYAML` and apply the default there instead of in `GetGroup`.
* The filter logic wasn't working [as documented](https://aws-nuke.ekristen.dev/features/filter-groups/). To keep a resource, all of the filter groups need to match, not one of them.
* Global filters were being ignored when filter groups are enabled.

I've added/updated tests accordingly. Some of the tests were incorrect, which is why they were previously passing. I've fixed these too.

Fixes #103 