### PR TITLE
feat(item): match on non-repeatable-key struct tag

### DIFF
--- a/pkg/queue/item.go
+++ b/pkg/queue/item.go
@@ -3,7 +3,6 @@ package queue
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"sort"
 	"strings"
 
@@ -114,78 +113,21 @@ func (i *Item) Equals(o resource.Resource) bool {
 		return false
 	}
 
-	// First check if the resources have nonRepeatableKey fields to compare
-	match, ok := compareNonRepeatableKeys(i.Resource, o)
-	if ok {
-		return match
+	// First check if the resources have non-repeatable keys to compare
+	iGetter, iOK := i.Resource.(resource.NonRepeatableKeyGetter)
+	oGetter, oOK := o.(resource.NonRepeatableKeyGetter)
+	if iOK && oOK {
+		return iGetter.NonRepeatableKey().Equals(oGetter.NonRepeatableKey())
 	}
-
-	// Remove below fallbacks once all resources use the libnuke:"nonRepeatableKey" struct tag
 
 	// Fall back to legacy string comparison (does not handle case when resource is recreated during nuke)
 	iStringer, iOK := i.Resource.(resource.LegacyStringer)
 	oStringer, oOK := o.(resource.LegacyStringer)
-	if iOK != oOK {
-		return false
-	}
 	if iOK && oOK {
 		return iStringer.String() == oStringer.String()
 	}
 
-	// Fall back to property comparison (does not handle case when properties change during nuke)
-	iGetter, iOK := i.Resource.(resource.PropertyGetter)
-	oGetter, oOK := o.(resource.PropertyGetter)
-	if iOK != oOK {
-		return false
-	}
-	if iOK && oOK {
-		return iGetter.Properties().Equals(oGetter.Properties())
-	}
-
 	return false
-}
-
-// compareNonRepeatableKeys compares the fields marked with libnuke tag containing 'nonRepeatableKey'
-// Returns (match result, whether any nonRepeatableKey fields were found)
-func compareNonRepeatableKeys(a any, b any) (bool, bool) {
-	aVal := reflect.ValueOf(a)
-	bVal := reflect.ValueOf(b)
-
-	if aVal.Kind() == reflect.Ptr {
-		aVal = aVal.Elem()
-	}
-	if bVal.Kind() == reflect.Ptr {
-		bVal = bVal.Elem()
-	}
-	if aVal.Kind() != reflect.Struct || bVal.Kind() != reflect.Struct {
-		return false, false
-	}
-
-	aType := aVal.Type()
-	foundNonRepeatableKey := false
-
-	// Iterate through struct fields looking for nonRepeatableKey tags
-	for i := 0; i < aType.NumField(); i++ {
-		field := aType.Field(i)
-		tagValue := field.Tag.Get("libnuke")
-		if tagValue == "" {
-			continue
-		}
-
-		tagParts := strings.Split(tagValue, ",")
-		for _, part := range tagParts {
-			if part == "nonRepeatableKey" {
-				foundNonRepeatableKey = true
-
-				if !reflect.DeepEqual(aVal.Field(i).Interface(), bVal.Field(i).Interface()) {
-					return false, true // Fields don't match, but we found nonRepeatableKey
-				}
-				break // No need to check other parts of this field's tag
-			}
-		}
-	}
-
-	return foundNonRepeatableKey, foundNonRepeatableKey
 }
 
 // Print displays the current status of an Item based on it's State

--- a/pkg/queue/item_test.go
+++ b/pkg/queue/item_test.go
@@ -281,6 +281,149 @@ func Test_ItemEqualStringer(t *testing.T) {
 
 // ------------------------------------------------------------------------
 
+type TestKeyedResource struct {
+	ID    *string `libnuke:"nonRepeatableKey"`
+	State *string
+}
+
+func (r *TestKeyedResource) Remove(_ context.Context) error {
+	return nil
+}
+
+func Test_ItemEqualNonRepeatableKeys(t *testing.T) {
+	id1 := "i-01b489457a60298dd"
+	state1 := "running"
+	r1 := &TestKeyedResource{ID: &id1, State: &state1}
+
+	id2 := "i-01b489457a60298dd" // Same ID
+	state2 := "stopping"         // Different state (should be ignored)
+	r2 := &TestKeyedResource{ID: &id2, State: &state2}
+
+	i := &Item{Resource: r1}
+	assert.True(t, i.Equals(r2), "Resources with same nonRepeatableKey should be equal")
+
+	// Test with non-matching nonRepeatableKeys
+	id3 := "i-1234567890abcdef0" // Different ID
+	state3 := "running"          // Same state (should be ignored)
+	r3 := &TestKeyedResource{ID: &id3, State: &state3}
+
+	assert.False(t, i.Equals(r3), "Resources with different nonRepeatableKey should not be equal")
+}
+
+// ------------------------------------------------------------------------
+
+type TestKeyedResourceWithTags struct {
+	ID    *string `property:"name=id" libnuke:"nonRepeatableKey,futureValue"`
+	State *string `property:"name=state"`
+}
+
+func (r *TestKeyedResourceWithTags) Remove(_ context.Context) error {
+	return nil
+}
+
+func Test_ItemEqualNonRepeatableKeyWithTags(t *testing.T) {
+	id1 := "i-01b489457a60298dd"
+	state1 := "running"
+	r1 := &TestKeyedResourceWithTags{ID: &id1, State: &state1}
+
+	id2 := "i-01b489457a60298dd" // Same ID
+	state2 := "stopping"         // Different state (should be ignored)
+	r2 := &TestKeyedResourceWithTags{ID: &id2, State: &state2}
+
+	i := &Item{Resource: r1}
+	assert.True(t, i.Equals(r2), "Should find nonRepeatableKey even when mixed with other tags")
+}
+
+// ------------------------------------------------------------------------
+
+type TestMultiKeyedResource struct {
+	Name         *string    `libnuke:"nonRepeatableKey"`
+	CreationTime *time.Time `libnuke:"nonRepeatableKey"`
+	LastEvent    *time.Time
+}
+
+func (r *TestMultiKeyedResource) Remove(_ context.Context) error {
+	return nil
+}
+
+func Test_ItemEqualMultipleNonRepeatableKeys(t *testing.T) {
+	now := time.Now()
+
+	name1 := "TestLogGroup"
+	creationTime1 := now
+	lastEvent1 := now
+	r1 := &TestMultiKeyedResource{Name: &name1, CreationTime: &creationTime1, LastEvent: &lastEvent1}
+
+	// All keys match
+	name2 := "TestLogGroup"
+	creationTime2 := now
+	lastEvent2 := now.Add(1 * time.Hour) // Should be ignored
+	r2 := &TestMultiKeyedResource{Name: &name2, CreationTime: &creationTime2, LastEvent: &lastEvent2}
+
+	i := &Item{Resource: r1}
+	assert.True(t, i.Equals(r2), "Resources with all matching keys should be equal")
+
+	// One key doesn't match
+	name3 := "TestLogGroup"
+	creationTime3 := now.Add(1 * time.Hour) // Different creation time (e.g. resource nuked but recreated before run finishes)
+	lastEvent3 := now.Add(1 * time.Hour)    // Should be ignored
+	r3 := &TestMultiKeyedResource{Name: &name3, CreationTime: &creationTime3, LastEvent: &lastEvent3}
+
+	assert.False(t, i.Equals(r3), "Resources with any non-matching key should not be equal")
+}
+
+// ------------------------------------------------------------------------
+
+type TestComplexKeyResource struct {
+	Name *string            `libnuke:"nonRepeatableKey"`
+	Tags map[string]*string `libnuke:"nonRepeatableKey"`
+}
+
+func (r *TestComplexKeyResource) Remove(_ context.Context) error {
+	return nil
+}
+
+func Test_ItemEqualComplexNonRepeatableKeys(t *testing.T) {
+	name1 := "resource-123"
+	tag1Value := "value1"
+	tag2Value := "value2"
+	tag3Value := "value3"
+
+	r1 := &TestComplexKeyResource{
+		Name: &name1,
+		Tags: map[string]*string{
+			"tag1": &tag1Value,
+			"tag2": &tag2Value,
+		},
+	}
+
+	// Same complex key values
+	name2 := "resource-123"
+	r2 := &TestComplexKeyResource{
+		Name: &name2,
+		Tags: map[string]*string{
+			"tag1": &tag1Value,
+			"tag2": &tag2Value,
+		},
+	}
+
+	// Different map contents
+	name3 := "resource-123"
+	r3 := &TestComplexKeyResource{
+		Name: &name3,
+		Tags: map[string]*string{
+			"tag1": &tag1Value,
+			"tag3": &tag3Value,
+		},
+	}
+
+	i := &Item{Resource: r1}
+	assert.True(t, i.Equals(r2), "Resources with same complex nonRepeatableKey should be equal")
+	assert.False(t, i.Equals(r3), "Resources with different complex nonRepeatableKey should not be equal")
+}
+
+// ------------------------------------------------------------------------
+
 type TestItemResourceNothing struct{}
 
 func (r *TestItemResourceNothing) Remove(_ context.Context) error {

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -33,6 +33,11 @@ type SettingsGetter interface {
 	Settings(setting *settings.Setting)
 }
 
+type NonRepeatableKeyGetter interface {
+	Resource
+	NonRepeatableKey() types.Properties
+}
+
 // HandleWaitHook is an interface that allows a resource to handle waiting for a resource to be deleted.
 // This is useful for resources that may take a while to delete, typically where the delete operation happens
 // asynchronously from the initial delete command. This allows libnuke to not block during the delete operation.


### PR DESCRIPTION
Fixes #100

I've used the terminology `nonRepeatableKey` but this can be changed if necessary.
