### PR TITLE
feat: unique key from struct

### DIFF
--- a/pkg/queue/item.go
+++ b/pkg/queue/item.go
@@ -125,7 +125,7 @@ func (i *Item) Equals(o resource.Resource) bool {
 	iUniqueKey := unique.FromStruct(i.Resource)
 	oUniqueKey := unique.FromStruct(o)
 	if iUniqueKey != nil && oUniqueKey != nil {
-		return iUniqueKey == oUniqueKey
+		return *iUniqueKey == *oUniqueKey
 	}
 
 	// Fall back to legacy string comparison (may not handle case where resource is recreated during nuke)

--- a/pkg/queue/item.go
+++ b/pkg/queue/item.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ekristen/libnuke/pkg/log"
 	"github.com/ekristen/libnuke/pkg/registry"
 	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/unique"
 )
 
 type ItemState int
@@ -118,6 +119,13 @@ func (i *Item) Equals(o resource.Resource) bool {
 	oKeyGetter, oOK := o.(resource.UniqueKeyGetter)
 	if iOK && oOK {
 		return iKeyGetter.UniqueKey() == oKeyGetter.UniqueKey()
+	}
+
+	// Compare unique keys from struct if available, if either are nil, move to next
+	iUniqueKey := unique.FromStruct(i.Resource)
+	oUniqueKey := unique.FromStruct(o)
+	if iUniqueKey != nil && oUniqueKey != nil {
+		return iUniqueKey == oUniqueKey
 	}
 
 	// Fall back to legacy string comparison (may not handle case where resource is recreated during nuke)

--- a/pkg/queue/item_test.go
+++ b/pkg/queue/item_test.go
@@ -533,3 +533,20 @@ func BenchmarkItemEquals(b *testing.B) {
 		}
 	})
 }
+
+type StructUniqueKeyResource struct {
+	ID string `libnuke:"uniqueKey"`
+}
+
+// Add Remove method to satisfy interface
+func (r *StructUniqueKeyResource) Remove(_ context.Context) error { return nil }
+
+func Test_ItemEquals_UniqueKeyFromStruct(t *testing.T) {
+	r1 := &StructUniqueKeyResource{ID: "abc123"}
+	r2 := &StructUniqueKeyResource{ID: "abc123"}
+	r3 := &StructUniqueKeyResource{ID: "def456"}
+
+	i := &Item{Resource: r1}
+	assert.True(t, i.Equals(r2), "Resources with same struct unique key should be equal")
+	assert.False(t, i.Equals(r3), "Resources with different struct unique key should not be equal")
+}

--- a/pkg/unique/unique.go
+++ b/pkg/unique/unique.go
@@ -3,20 +3,23 @@ package unique
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
 	"reflect"
-	"strings"
 )
 
 // Generate creates a unique hash from a slice of interface{} values.
 func Generate(data ...interface{}) string {
-	var values []string
-
-	for d := range data {
-		values = append(values, toString(d))
+	var allBytes []byte
+	for _, d := range data {
+		b, err := json.Marshal(d)
+		if err != nil {
+			// fallback: use fmt.Sprintf if marshal fails
+			b = []byte(fmt.Sprintf("%v", d))
+		}
+		allBytes = append(allBytes, b...)
 	}
-
-	combined := strings.Join(values, ",")
-	hash := sha256.Sum256([]byte(combined))
+	hash := sha256.Sum256(allBytes)
 	return hex.EncodeToString(hash[:])
 }
 

--- a/pkg/unique/unique_test.go
+++ b/pkg/unique/unique_test.go
@@ -152,3 +152,41 @@ func TestFromStruct_Nil(t *testing.T) {
 		t.Errorf("expected nil for nil, got: %v", *key)
 	}
 }
+
+func TestGenerate_HashDeterminism(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []interface{}
+		expect string
+	}{
+		{
+			name:   "simple strings",
+			input:  []interface{}{"foo", "bar"},
+			expect: "e3066f35bf392a7f15f2ec7497bcafd3330d83b9f83a2df979b65df9d3bdeef9", // placeholder, replace with actual
+		},
+		{
+			name:   "numbers and bool",
+			input:  []interface{}{123, true, 45.6},
+			expect: "55f056c6cecba8e5b99ebae70af5e4ff1c476e1c35f3ee8d161b29de4468d459", // placeholder
+		},
+		{
+			name:   "struct",
+			input:  []interface{}{struct{ A string }{A: "x"}},
+			expect: "cfd8d2a6c2fa8b7693ab816dc210246ff285a42bf21124ece9f869326af35e24", // placeholder
+		},
+		{
+			name:   "slice",
+			input:  []interface{}{[]int{1, 2, 3}},
+			expect: "a615eeaee21de5179de080de8c3052c8da901138406ba71c38c032845f7d54f4", // placeholder
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hash := Generate(tt.input...)
+			if hash != tt.expect {
+				t.Errorf("expected %s, got %s", tt.expect, hash)
+			}
+		})
+	}
+}

--- a/pkg/unique/unique_test.go
+++ b/pkg/unique/unique_test.go
@@ -190,3 +190,16 @@ func TestGenerate_HashDeterminism(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerate_JSONMarshalError(t *testing.T) {
+	type Unmarshalable struct {
+		Ch chan int
+	}
+	// Channels cannot be marshaled by encoding/json
+	input := Unmarshalable{Ch: make(chan int)}
+	// Should not panic, should fallback to fmt.Sprintf
+	hash := Generate(input)
+	if hash == "" {
+		t.Error("expected non-empty hash even if JSON marshal fails")
+	}
+}


### PR DESCRIPTION
adds a feature to get a unique key from the resource struct automatically.

The order of preference is going to be:

1. UniqueKey func if present
2. Attempt to automatically detect unique key from `libnuke` tag
3. Stringer match
4. Properties match