### PR TITLE
feat: add configuration flag to support maximum retries on resource failure

### DIFF
--- a/pkg/nuke/nuke.go
+++ b/pkg/nuke/nuke.go
@@ -28,11 +28,12 @@ type ListCache map[string]map[string][]resource.Resource
 
 // Parameters is a collection of common variables used to configure the before of the Nuke instance.
 type Parameters struct {
-	NoDryRun       bool // NoDryRun instructs Run to actually perform the remove function
-	Force          bool // Force instructs Run to proceed without confirmation from user
-	ForceSleep     int  // ForceSleep indicates how long of a delay before proceeding with confirmation
-	Quiet          bool // Quiet will hide resources if they have been filtered
-	MaxWaitRetries int  // MaxWaitRetries is the total number of times a resource will be retried during wait state
+	NoDryRun          bool // NoDryRun instructs Run to actually perform the remove function
+	Force             bool // Force instructs Run to proceed without confirmation from user
+	ForceSleep        int  // ForceSleep indicates how long of a delay before proceeding with confirmation
+	Quiet             bool // Quiet will hide resources if they have been filtered
+	MaxWaitRetries    int  // MaxWaitRetries is the total number of times a resource will be retried during wait state
+	MaxFailureRetries int  // MaxFailureRetries is the total number of times a resource will be retried during failure state
 
 	// WaitOnDependencies controls whether resources will be removed after their dependencies. It is important to note
 	// that it does not currently track direct dependencies but instead dependent resources. For example if ResourceA
@@ -253,8 +254,8 @@ func (n *Nuke) handleFailure() error {
 	// if there are no resources being processed and there are resources in the failed state, then we enter this
 	// loop to determine how many times we've tried the failed resources
 	if processingCount == 0 && failedCount > 0 {
-		// if failCount is greater than 2, then we are done, print status and return failed error
-		if n.failedCount >= 2 {
+		// if failCount is greater than max failure retries, then we are done, print status and return failed error
+		if n.failedCount >= n.Parameters.MaxFailureRetries {
 			printLog.Errorf("There are resources in failed state, but none are ready for deletion, anymore.")
 
 			for _, item := range n.Queue.GetItems() {
@@ -355,6 +356,11 @@ func (n *Nuke) Version() {
 func (n *Nuke) Validate() error {
 	if n.Parameters.ForceSleep < 3 {
 		return fmt.Errorf("value for --force-sleep cannot be less than 3 seconds. This is for your own protection")
+	}
+
+	// set a default of 3 for max failure retries
+	if n.Parameters.MaxFailureRetries == 0 {
+		n.Parameters.MaxFailureRetries = 3
 	}
 
 	if err := n.Filters.Validate(); err != nil {

--- a/pkg/nuke/nuke_run_test.go
+++ b/pkg/nuke/nuke_run_test.go
@@ -245,6 +245,7 @@ func Test_Nuke_Run_Failure(t *testing.T) {
 
 	assert.Equal(t, 1, n.Queue.Count(queue.ItemStateFinished))
 	assert.Equal(t, 1, n.Queue.Count(queue.ItemStateFailed))
+	assert.Equal(t, testParametersRemove.MaxFailureRetries, n.failedCount)
 }
 
 var testParametersMaxWaitRetries = &Parameters{

--- a/pkg/nuke/nuke_test.go
+++ b/pkg/nuke/nuke_test.go
@@ -27,10 +27,11 @@ var testParameters = &Parameters{
 }
 
 var testParametersRemove = &Parameters{
-	Force:      true,
-	ForceSleep: 3,
-	Quiet:      true,
-	NoDryRun:   true,
+	Force:             true,
+	ForceSleep:        3,
+	Quiet:             true,
+	NoDryRun:          true,
+	MaxFailureRetries: 6,
 }
 
 var testParametersGroups = &Parameters{

--- a/pkg/nuke/nuke_test.go
+++ b/pkg/nuke/nuke_test.go
@@ -56,7 +56,7 @@ func Test_Nuke_Version(t *testing.T) {
 				return
 			}
 
-			if e.Caller.Line == 351 {
+			if e.Caller.Line == 352 {
 				assert.Equal(t, "1.0.0-test", e.Message)
 				assertions++
 			}


### PR DESCRIPTION
This PR adds a configuration parameter that controls the number of times to retry when no work remains but failed dependencies. Increasing this from the previous default of `3` can help when some resources need more time between being deleted and other resources that depend upon them being eligible for deletion. 

Fixes: https://github.com/ekristen/aws-nuke/issues/760