### PR TITLE
feat: phased resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 coverage.txt
+.claude

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,63 @@
+# Agents
+
+## Project Overview
+
+libnuke is a Go library that provides the core framework for cloud resource cleanup tools (aws-nuke, azure-nuke, gcp-nuke). It handles resource discovery, filtering, queuing, and removal orchestration.
+
+## Language & Build
+
+- Go 1.24+
+- Module: `github.com/ekristen/libnuke`
+- No main package — this is a library
+
+## Project Structure
+
+```
+pkg/
+├── nuke/       Core orchestrator (validate → prompt → scan → filter → remove)
+├── queue/      Resource processing queue with 9-state lifecycle
+├── scanner/    Parallel resource discovery
+├── filter/     Multi-type filtering (exact, glob, regex, date, etc.)
+├── registry/   Global resource type registry with dependency sorting
+├── resource/   Resource interfaces
+├── config/     YAML configuration parsing
+├── settings/   Per-resource-type settings
+├── types/      Properties collection and type utilities
+├── errors/     Custom error types
+├── log/        Colored logging utilities
+├── utils/      Helpers (UniqueID, Prompt)
+├── slices/     Generic slice utilities
+├── unique/     Unique key generation
+└── docs/       Documentation generation
+```
+
+## Commands
+
+- **Test:** `go test ./...`
+- **Test single package:** `go test ./pkg/nuke/...`
+- **Lint:** `golangci-lint run`
+- **Tidy:** `go mod tidy`
+
+## Code Style & Conventions
+
+- Follow idiomatic Go conventions
+- Use `context.Context` propagation throughout
+- Use `logrus` for structured logging
+- Lint rules: gocyclo limit 15, funlen limit 100 (relaxed in test files)
+- Test files use `testify/assert` and `testify/suite`
+- Resources implement optional interfaces to opt into capabilities (Filter, PropertyGetter, SettingsGetter, etc.)
+- Register resource types via the global registry in `pkg/registry/`
+
+## Key Interfaces
+
+- `resource.Resource` — Base: `Remove(ctx) error`
+- `resource.Filter` — Per-resource filtering: `Filter() error`
+- `resource.PropertyGetter` — `Properties() types.Properties`
+- `registry.Lister` — `List(ctx, opts) ([]resource.Resource, error)`
+
+## Testing
+
+- Every package should have corresponding `_test.go` files
+- Use table-driven tests where appropriate
+- Mock resources and listers are defined in `pkg/nuke/testsuite_test.go` and `pkg/scanner/testsuite_test.go`
+- Do not disable linting rules in non-test code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -50,12 +50,14 @@ type ResourceTypes struct {
 
 	// Targets is a list of resource types that are to be included during the nuke process. If a resource type is
 	// listed in both the Targets and Excludes fields then the Excludes field will take precedence.
+	//
 	// Deprecated: Use Includes instead.
 	Targets types.Collection `yaml:"targets"`
 
 	// CloudControl is a list of resource types that are to be used with the Cloud Control API. This is a Resource
 	// level alternative. This was left in place to make the transition to libnuke and ekristen/aws-nuke@v3 easier
 	// for existing users.
+	//
 	// Deprecated: Use Alternatives instead.
 	CloudControl types.Collection `yaml:"cloud-control"`
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -39,6 +39,12 @@ func (err ErrDeprecatedResourceType) Error() string {
 	return string(err)
 }
 
+type ErrResetPhases string
+
+func (err ErrResetPhases) Error() string {
+	return string(err)
+}
+
 var ErrNoBlocklistDefined = errors.New("no blocklist defined")
 var ErrBlocklistAccount = errors.New("account is in blocklist")
 var ErrAccountNotConfigured = errors.New("account is not configured")

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -31,6 +31,7 @@ func TestErrors(t *testing.T) {
 		{liberrors.ErrHoldResource(testStringValue)},
 		{liberrors.ErrUnknownPreset(testStringValue)},
 		{liberrors.ErrDeprecatedResourceType(testStringValue)},
+		{liberrors.ErrResetPhases(testStringValue)},
 	}
 
 	for _, c := range cases {

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -128,6 +128,7 @@ func (f Filters) Append(f2 Filters) {
 }
 
 // Merge is an alias of Append for backwards compatibility
+//
 // Deprecated: use Append instead
 func (f Filters) Merge(f2 Filters) {
 	f.Append(f2)

--- a/pkg/nuke/nuke.go
+++ b/pkg/nuke/nuke.go
@@ -563,6 +563,13 @@ func (n *Nuke) HandleQueue(ctx context.Context) {
 	listCache := make(map[string]map[string][]resource.Resource)
 
 	for _, item := range n.Queue.GetItems() {
+		// Check if this resource uses the phased removal flow
+		phased, isPhased := item.Resource.(resource.PhasedResource)
+		if isPhased && len(phased.Phases()) > 0 {
+			n.handlePhasedItem(ctx, item, phased, listCache)
+			continue
+		}
+
 		switch item.GetState() {
 		case queue.ItemStateNew, queue.ItemStateHold:
 			n.HandleRemove(ctx, item)
@@ -629,7 +636,8 @@ func (n *Nuke) HandleRemove(ctx context.Context, item *queue.Item) {
 }
 
 // HandleWaitDependency is used to handle the waiting of a resource. It will check if the resource has any dependencies
-// and if it does, it will check if the dependencies have been removed. If they have, it will trigger the remove handler.
+// and if it does, it will check if the dependencies have been removed. If they have, it will trigger the remove handler
+// or the phase handler for phased resources.
 func (n *Nuke) HandleWaitDependency(ctx context.Context, item *queue.Item) {
 	reg := registry.GetRegistration(item.Type)
 	depCount := 0
@@ -642,6 +650,13 @@ func (n *Nuke) HandleWaitDependency(ctx context.Context, item *queue.Item) {
 	}
 
 	if depCount == 0 {
+		// If the resource is phased, start the phase flow instead of Remove
+		if phased, ok := item.Resource.(resource.PhasedResource); ok && len(phased.Phases()) > 0 {
+			cache := make(ListCache)
+			n.HandlePhase(ctx, item, phased, cache)
+			return
+		}
+
 		n.HandleRemove(ctx, item)
 		return
 	}
@@ -709,4 +724,87 @@ func (n *Nuke) HandleWait(ctx context.Context, item *queue.Item, cache ListCache
 
 	item.State = queue.ItemStateFinished
 	item.Reason = ""
+}
+
+// handlePhasedItem handles resources that implement PhasedResource. It routes the item through its phase lifecycle
+// while respecting dependency ordering and existing state transitions.
+func (n *Nuke) handlePhasedItem(ctx context.Context, item *queue.Item, phased resource.PhasedResource, cache ListCache) {
+	switch item.GetState() {
+	case queue.ItemStateNewDependency, queue.ItemStatePendingDependency:
+		n.HandleWaitDependency(ctx, item)
+		item.Print()
+	case queue.ItemStateNew, queue.ItemStateHold, queue.ItemStateFailed:
+		n.HandlePhase(ctx, item, phased, cache)
+		item.Print()
+	case queue.ItemStatePending:
+		n.HandlePhase(ctx, item, phased, cache)
+		item.Print()
+	case queue.ItemStateWaiting:
+		n.HandlePhase(ctx, item, phased, cache)
+		item.Print()
+	case queue.ItemStateFiltered, queue.ItemStateFinished:
+		// no-op
+	}
+}
+
+// HandlePhase advances a phased resource through its next phase. It is called on each queue iteration for resources
+// that implement PhasedResource. When all phases complete, it falls through to the list-check to verify removal.
+func (n *Nuke) HandlePhase(ctx context.Context, item *queue.Item, phased resource.PhasedResource, cache ListCache) {
+	phases := phased.Phases()
+
+	// All phases complete — verify resource is actually gone via list-check
+	if item.PhaseIndex >= len(phases) {
+		n.HandleWait(ctx, item, cache)
+		return
+	}
+
+	current := phases[item.PhaseIndex]
+	item.Phase = current.Name
+
+	err := current.Run(ctx)
+	if err == nil {
+		// Phase completed, advance to next
+		item.PhaseIndex++
+
+		if item.PhaseIndex >= len(phases) {
+			// All phases done, move to pending for list-check on next iteration
+			item.State = queue.ItemStatePending
+			item.Phase = ""
+		} else {
+			// More phases remain, stay pending
+			item.State = queue.ItemStatePending
+			item.Phase = phases[item.PhaseIndex].Name
+		}
+
+		item.Reason = ""
+		return
+	}
+
+	// Handle specific error types
+	var waitErr liberrors.ErrWaitResource
+	if errors.As(err, &waitErr) {
+		item.State = queue.ItemStateWaiting
+		item.Reason = waitErr.Error()
+		return
+	}
+
+	var holdErr liberrors.ErrHoldResource
+	if errors.As(err, &holdErr) {
+		item.State = queue.ItemStateHold
+		item.Reason = holdErr.Error()
+		return
+	}
+
+	var resetErr liberrors.ErrResetPhases
+	if errors.As(err, &resetErr) {
+		item.PhaseIndex = 0
+		item.State = queue.ItemStateFailed
+		item.Phase = phases[0].Name
+		item.Reason = resetErr.Error()
+		return
+	}
+
+	// Any other error — failed, will retry current phase
+	item.State = queue.ItemStateFailed
+	item.Reason = err.Error()
 }

--- a/pkg/nuke/nuke_phased_test.go
+++ b/pkg/nuke/nuke_phased_test.go
@@ -1,0 +1,398 @@
+package nuke
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ekristen/libnuke/pkg/errors"
+	"github.com/ekristen/libnuke/pkg/queue"
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/scanner"
+)
+
+// --- Test phased resources ---
+
+// TestPhasedResource implements a resource with two sync phases (disable protection + delete)
+type TestPhasedResource struct {
+	DisableCalled bool
+	DeleteCalled  bool
+}
+
+func (r *TestPhasedResource) Remove(_ context.Context) error { return nil }
+func (r *TestPhasedResource) String() string                 { return "TestPhasedResource" }
+
+func (r *TestPhasedResource) Phases() []resource.Phase {
+	return []resource.Phase{
+		{Name: "disable-protection", Run: r.disableProtection},
+		{Name: "delete", Run: r.delete},
+	}
+}
+
+func (r *TestPhasedResource) disableProtection(_ context.Context) error {
+	r.DisableCalled = true
+	return nil
+}
+
+func (r *TestPhasedResource) delete(_ context.Context) error {
+	r.DeleteCalled = true
+	return nil
+}
+
+type TestPhasedResourceLister struct {
+	listed bool
+}
+
+func (l *TestPhasedResourceLister) List(_ context.Context, _ interface{}) ([]resource.Resource, error) {
+	if l.listed {
+		return []resource.Resource{}, nil
+	}
+	l.listed = true
+	return []resource.Resource{&TestPhasedResource{}}, nil
+}
+
+// TestPhasedResourceAsync implements a resource with async phases
+type TestPhasedResourceAsync struct {
+	disableWaitCount int
+	deleteWaitCount  int
+}
+
+func (r *TestPhasedResourceAsync) Remove(_ context.Context) error { return nil }
+func (r *TestPhasedResourceAsync) String() string                 { return "TestPhasedResourceAsync" }
+
+func (r *TestPhasedResourceAsync) Phases() []resource.Phase {
+	return []resource.Phase{
+		{Name: "disable-protection", Run: r.disableProtection},
+		{Name: "delete", Run: r.delete},
+	}
+}
+
+func (r *TestPhasedResourceAsync) disableProtection(_ context.Context) error {
+	r.disableWaitCount++
+	if r.disableWaitCount < 3 {
+		return errors.ErrWaitResource("waiting for disable")
+	}
+	return nil
+}
+
+func (r *TestPhasedResourceAsync) delete(_ context.Context) error {
+	r.deleteWaitCount++
+	if r.deleteWaitCount < 2 {
+		return errors.ErrWaitResource("waiting for delete")
+	}
+	return nil
+}
+
+type TestPhasedResourceAsyncLister struct {
+	listed bool
+}
+
+func (l *TestPhasedResourceAsyncLister) List(_ context.Context, _ interface{}) ([]resource.Resource, error) {
+	if l.listed {
+		return []resource.Resource{}, nil
+	}
+	l.listed = true
+	return []resource.Resource{&TestPhasedResourceAsync{}}, nil
+}
+
+// TestPhasedResourceFail implements a resource where a phase fails
+type TestPhasedResourceFail struct {
+	attempts int
+}
+
+func (r *TestPhasedResourceFail) Remove(_ context.Context) error { return nil }
+func (r *TestPhasedResourceFail) String() string                 { return "TestPhasedResourceFail" }
+
+func (r *TestPhasedResourceFail) Phases() []resource.Phase {
+	return []resource.Phase{
+		{Name: "disable-protection", Run: r.disableProtection},
+		{Name: "delete", Run: r.delete},
+	}
+}
+
+func (r *TestPhasedResourceFail) disableProtection(_ context.Context) error {
+	return nil
+}
+
+func (r *TestPhasedResourceFail) delete(_ context.Context) error {
+	r.attempts++
+	return fmt.Errorf("delete failed")
+}
+
+type TestPhasedResourceFailLister struct{}
+
+func (l *TestPhasedResourceFailLister) List(_ context.Context, _ interface{}) ([]resource.Resource, error) {
+	return []resource.Resource{&TestPhasedResourceFail{}}, nil
+}
+
+// TestPhasedResourceReset implements a resource that resets phases
+type TestPhasedResourceReset struct {
+	resetCount     int
+	disableCalls   int
+	deleteCalls    int
+	maxResets      int
+	deleteSucceeds bool
+}
+
+func (r *TestPhasedResourceReset) Remove(_ context.Context) error { return nil }
+func (r *TestPhasedResourceReset) String() string                 { return "TestPhasedResourceReset" }
+
+func (r *TestPhasedResourceReset) Phases() []resource.Phase {
+	return []resource.Phase{
+		{Name: "disable-protection", Run: r.disableProtection},
+		{Name: "delete", Run: r.delete},
+	}
+}
+
+func (r *TestPhasedResourceReset) disableProtection(_ context.Context) error {
+	r.disableCalls++
+	return nil
+}
+
+func (r *TestPhasedResourceReset) delete(_ context.Context) error {
+	r.deleteCalls++
+	if r.deleteSucceeds {
+		return nil
+	}
+	if r.resetCount < r.maxResets {
+		r.resetCount++
+		return errors.ErrResetPhases("need to start over")
+	}
+	// After max resets, succeed
+	r.deleteSucceeds = true
+	return nil
+}
+
+type TestPhasedResourceResetLister struct {
+	listed bool
+}
+
+func (l *TestPhasedResourceResetLister) List(_ context.Context, _ interface{}) ([]resource.Resource, error) {
+	if l.listed {
+		return []resource.Resource{}, nil
+	}
+	l.listed = true
+	return []resource.Resource{&TestPhasedResourceReset{maxResets: 1}}, nil
+}
+
+// --- Tests ---
+
+func TestNuke_PhasedResource_SyncPhases(t *testing.T) {
+	n := New(testParametersRemove, nil, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
+
+	registry.ClearRegistry()
+	registry.Register(&registry.Registration{
+		Name:   "TestPhasedResource",
+		Lister: &TestPhasedResourceLister{},
+	})
+
+	s, err := scanner.New(&scanner.Config{
+		Owner:         "Owner",
+		ResourceTypes: []string{"TestPhasedResource"},
+		Opts:          nil,
+	})
+	assert.NoError(t, err)
+
+	scannerErr := n.RegisterScanner(testScope, s)
+	assert.NoError(t, scannerErr)
+
+	runErr := n.Run(context.TODO())
+	assert.NoError(t, runErr)
+
+	assert.Equal(t, 1, n.Queue.Count(queue.ItemStateFinished))
+}
+
+func TestNuke_PhasedResource_AsyncPhases(t *testing.T) {
+	n := New(testParametersRemove, nil, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
+
+	registry.ClearRegistry()
+	registry.Register(&registry.Registration{
+		Name:   "TestPhasedResourceAsync",
+		Lister: &TestPhasedResourceAsyncLister{},
+	})
+
+	s, err := scanner.New(&scanner.Config{
+		Owner:         "Owner",
+		ResourceTypes: []string{"TestPhasedResourceAsync"},
+		Opts:          nil,
+	})
+	assert.NoError(t, err)
+
+	scannerErr := n.RegisterScanner(testScope, s)
+	assert.NoError(t, scannerErr)
+
+	runErr := n.Run(context.TODO())
+	assert.NoError(t, runErr)
+
+	assert.Equal(t, 1, n.Queue.Count(queue.ItemStateFinished))
+}
+
+func TestNuke_PhasedResource_FailRetries(t *testing.T) {
+	n := New(testParametersRemove, nil, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
+
+	registry.ClearRegistry()
+	registry.Register(&registry.Registration{
+		Name:   "TestPhasedResourceFail",
+		Lister: &TestPhasedResourceFailLister{},
+	})
+
+	s, err := scanner.New(&scanner.Config{
+		Owner:         "Owner",
+		ResourceTypes: []string{"TestPhasedResourceFail"},
+		Opts:          nil,
+	})
+	assert.NoError(t, err)
+
+	scannerErr := n.RegisterScanner(testScope, s)
+	assert.NoError(t, scannerErr)
+
+	runErr := n.Run(context.TODO())
+	assert.Error(t, runErr)
+
+	assert.Equal(t, 1, n.Queue.Count(queue.ItemStateFailed))
+	// Verify it retried at the delete phase (phase index should still be 1, not 0)
+	for _, item := range n.Queue.GetItems() {
+		if item.GetState() == queue.ItemStateFailed {
+			assert.Equal(t, 1, item.PhaseIndex, "should retry at the failed phase, not reset to 0")
+		}
+	}
+}
+
+func TestNuke_PhasedResource_ResetPhases(t *testing.T) {
+	n := New(testParametersRemove, nil, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
+
+	registry.ClearRegistry()
+	registry.Register(&registry.Registration{
+		Name:   "TestPhasedResourceReset",
+		Lister: &TestPhasedResourceResetLister{},
+	})
+
+	s, err := scanner.New(&scanner.Config{
+		Owner:         "Owner",
+		ResourceTypes: []string{"TestPhasedResourceReset"},
+		Opts:          nil,
+	})
+	assert.NoError(t, err)
+
+	scannerErr := n.RegisterScanner(testScope, s)
+	assert.NoError(t, scannerErr)
+
+	runErr := n.Run(context.TODO())
+	assert.NoError(t, runErr)
+
+	assert.Equal(t, 1, n.Queue.Count(queue.ItemStateFinished))
+}
+
+func TestNuke_PhasedResource_WithDependencies(t *testing.T) {
+	n := New(&Parameters{
+		Force:              true,
+		ForceSleep:         3,
+		Quiet:              true,
+		NoDryRun:           true,
+		WaitOnDependencies: true,
+	}, nil, nil)
+	n.SetLogger(logrus.WithField("test", true))
+	n.SetRunSleep(time.Millisecond * 5)
+
+	registry.ClearRegistry()
+	registry.Register(&registry.Registration{
+		Name:   "TestPhasedResource",
+		Lister: &TestPhasedResourceLister{},
+	})
+	registry.Register(&registry.Registration{
+		Name:   "TestPhasedResourceDependent",
+		Lister: &TestPhasedResourceLister{},
+		DependsOn: []string{
+			"TestPhasedResource",
+		},
+	})
+
+	s, err := scanner.New(&scanner.Config{
+		Owner:         "Owner",
+		ResourceTypes: []string{"TestPhasedResource", "TestPhasedResourceDependent"},
+		Opts:          nil,
+	})
+	assert.NoError(t, err)
+
+	scannerErr := n.RegisterScanner(testScope, s)
+	assert.NoError(t, scannerErr)
+
+	runErr := n.Run(context.TODO())
+	assert.NoError(t, runErr)
+
+	assert.Equal(t, 2, n.Queue.Count(queue.ItemStateFinished))
+}
+
+func TestNuke_HandlePhase_Direct(t *testing.T) {
+	n := New(testParameters, nil, nil)
+	n.SetLogger(logrus.WithField("test", true))
+
+	res := &TestPhasedResource{}
+	item := &queue.Item{
+		Resource: res,
+		State:    queue.ItemStateNew,
+		Type:     "TestPhasedResource",
+	}
+
+	// First call: runs disable-protection phase
+	n.HandlePhase(context.TODO(), item, res, make(ListCache))
+	assert.Equal(t, queue.ItemStatePending, item.State)
+	assert.Equal(t, 1, item.PhaseIndex)
+	assert.True(t, res.DisableCalled)
+	assert.False(t, res.DeleteCalled)
+
+	// Second call: runs delete phase
+	n.HandlePhase(context.TODO(), item, res, make(ListCache))
+	assert.Equal(t, queue.ItemStatePending, item.State)
+	assert.Equal(t, 2, item.PhaseIndex)
+	assert.True(t, res.DeleteCalled)
+}
+
+func TestNuke_HandlePhase_HoldError(t *testing.T) {
+	n := New(testParameters, nil, nil)
+	n.SetLogger(logrus.WithField("test", true))
+
+	res := &TestPhasedResourceHold{}
+	item := &queue.Item{
+		Resource: res,
+		State:    queue.ItemStateNew,
+		Type:     "TestPhasedResourceHold",
+	}
+
+	n.HandlePhase(context.TODO(), item, res, make(ListCache))
+	assert.Equal(t, queue.ItemStateHold, item.State)
+}
+
+// TestPhasedResourceHold is a phased resource where the first phase returns ErrHoldResource
+type TestPhasedResourceHold struct{}
+
+func (r *TestPhasedResourceHold) Remove(_ context.Context) error { return nil }
+func (r *TestPhasedResourceHold) String() string                 { return "TestPhasedResourceHold" }
+
+func (r *TestPhasedResourceHold) Phases() []resource.Phase {
+	return []resource.Phase{
+		{Name: "wait-for-parent", Run: r.waitForParent},
+		{Name: "delete", Run: r.delete},
+	}
+}
+
+func (r *TestPhasedResourceHold) waitForParent(_ context.Context) error {
+	return errors.ErrHoldResource("parent not ready")
+}
+
+func (r *TestPhasedResourceHold) delete(_ context.Context) error {
+	return nil
+}

--- a/pkg/nuke/nuke_test.go
+++ b/pkg/nuke/nuke_test.go
@@ -88,7 +88,7 @@ func TestNuke_Settings(t *testing.T) {
 
 	testResourceSettings := n.Settings.Get("TestResource")
 	assert.NotNil(t, testResourceSettings)
-	assert.Equal(t, true, testResourceSettings.Get("DisableDeletionProtection"))
+	assert.Equal(t, true, testResourceSettings.GetBool("DisableDeletionProtection"))
 }
 
 func Test_Nuke_Validators_Default(t *testing.T) {

--- a/pkg/queue/item.go
+++ b/pkg/queue/item.go
@@ -70,6 +70,9 @@ type Item struct {
 	Owner    string // region/subscription
 	Opts     interface{}
 	Logger   *logrus.Logger
+
+	Phase      string // Phase is the current phase name for logging (used by PhasedResource)
+	PhaseIndex int    // PhaseIndex is the current position in the phase list (used by PhasedResource)
 }
 
 // GetState returns the current State of the Item
@@ -167,6 +170,10 @@ func (i *Item) Print() {
 	rProp, ok := i.Resource.(resource.PropertyGetter)
 	if ok {
 		itemLog = itemLog.WithFields(sorted(rProp.Properties()))
+	}
+
+	if i.Phase != "" {
+		itemLog = itemLog.WithField("phase", i.Phase)
 	}
 
 	switch i.State {

--- a/pkg/queue/item_test.go
+++ b/pkg/queue/item_test.go
@@ -402,6 +402,35 @@ func (r *TestItemResourceLogger) Remove(_ context.Context) error {
 	return nil
 }
 
+func Test_ItemPrintWithPhase(t *testing.T) {
+	logger := logrus.New()
+	defer func() {
+		logger.ReplaceHooks(make(logrus.LevelHooks))
+	}()
+
+	hookCalled := false
+	logger.AddHook(&TestGlobalHook{
+		t: t,
+		tf: func(t *testing.T, e *logrus.Entry) {
+			hookCalled = true
+			assert.Equal(t, "disable-protection", e.Data["phase"])
+			assert.Equal(t, "triggered remove", e.Message)
+		},
+	})
+
+	i := &Item{
+		Resource: &TestItemResourceLogger{},
+		State:    ItemStatePending,
+		Type:     "TestResource",
+		Owner:    "us-east-1",
+		Phase:    "disable-protection",
+		Logger:   logger,
+	}
+
+	i.Print()
+	assert.True(t, hookCalled)
+}
+
 func Test_ItemLoggerDefault(t *testing.T) {
 	i := &Item{
 		Resource: &TestItemResourceLogger{},

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -60,3 +60,25 @@ type QueueItemHook interface {
 	Resource
 	BeforeEnqueue(interface{})
 }
+
+// PhaseFunc is a function that executes a single phase of a resource's removal process.
+// Return nil to advance to the next phase.
+// Return ErrWaitResource to stay on this phase and be polled again next iteration.
+// Return ErrHoldResource to hold the resource.
+// Return ErrResetPhases to reset to phase 0 and start over.
+// Return any other error to move the resource to failed state (retries current phase).
+type PhaseFunc func(ctx context.Context) error
+
+// Phase represents a single named step in a resource's removal process.
+type Phase struct {
+	Name string
+	Run  PhaseFunc
+}
+
+// PhasedResource is an interface that allows a resource to define a multi-step removal process.
+// Each phase can be synchronous or asynchronous. When implemented, libnuke calls phases sequentially
+// instead of calling Remove(). The resource's Remove() method should be a no-op when Phases() is used.
+type PhasedResource interface {
+	Resource
+	Phases() []Phase
+}

--- a/pkg/resource/resource_test.go
+++ b/pkg/resource/resource_test.go
@@ -76,7 +76,7 @@ func TestInterface_SettingsGetter(t *testing.T) {
 	r := TestResource{}
 	r.Settings(s.Get("TestResource"))
 
-	assert.Equal(t, true, r.settings.Get("DisableDeletionProtection"))
+	assert.Equal(t, true, r.settings.GetBool("DisableDeletionProtection"))
 }
 
 func TestInterfaceUniqueKeyGetter(t *testing.T) {

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -32,6 +32,7 @@ func (s *Settings) Set(key string, value *Setting) {
 type Setting map[string]interface{}
 
 // Get returns the value of a key in the Setting
+//
 // Deprecated: use GetBool, GetString, or GetInt instead
 func (s *Setting) Get(key string) interface{} {
 	value, ok := (*s)[key]


### PR DESCRIPTION
## Summary

- Adds a PhasedResource interface that allows resource to defined a multi-step removal workflow. 
- Each phase is a named function that controls flow via error with nil to advance, **ErrWaitResource** to poll, **ErrHoldResource** to pause and **ErrResetPhase**  to restart from phase 0.
- Phase state is tracked per queue item (Phase Name + Phase Index displayed)
- Resources implementing the PhasedResource interface are automatically routed through the phased orchestrator

## Motivation

Between some cloud resources requiring multiple steps to remove and those steps becoming asynchronous we need a way to properly handle it. Previously all steps had to be synchronous within the Remove method, but due to the asynchronous nature, this was causing the need for more resources to implement HandleWait, but that meant doing actual removes in HandleWait method, which isn’t a natural place to think a remove should take place.

## Known Limitation

If you implement a phased method wrong it can get stuck in a wait state forever, need to ensure that all phased functions properly return properly and check the async status of the cloud resource properly.