### PR TITLE
docs: Add stackit-nuke link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Most of this code originated from the original [aws-nuke](https://github.com/reb
   - was originally a managed fork, it's now been split entirely from the original project, too much divergence
 - [aws-nuke original](https://github.com/rebuy-de/aws-nuke)
 - [azure-nuke](https://github.com/ekristen/azure-nuke)
+- [stackit-nuke](https://github.com/qaiser42/stackit-nuke)
 
 ## Versioning
 


### PR DESCRIPTION
Hi @ekristen,

Thanks for libnuke and the clean separation from aws-nuke — made it
much easier to build on top of than forking would have.

I've built stackit-nuke (https://github.com/qaiser42/stackit-nuke),
targeting STACKIT (German cloud, operated by Schwarz Gruppe).
Currently using it in a client project.
